### PR TITLE
Replace Moq with NSubstitute and MockHttp

### DIFF
--- a/src/Core/Common/Hexalith.TestMocks/Hexalith.TestMocks.csproj
+++ b/src/Core/Common/Hexalith.TestMocks/Hexalith.TestMocks.csproj
@@ -10,7 +10,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"  />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions"  />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  />
-        <PackageReference Include="Moq"  />
+        <PackageReference Include="NSubstitute"  />
+        <PackageReference Include="RichardSzalay.MockHttp"  />
         <PackageReference Include="xunit"  />
     </ItemGroup>
     <ItemGroup>

--- a/src/Core/Common/Hexalith.TestMocks/IMockBuilder.cs
+++ b/src/Core/Common/Hexalith.TestMocks/IMockBuilder.cs
@@ -1,11 +1,9 @@
-﻿// <copyright file="IMockBuilder.cs" company="ITANEO">
+// <copyright file="IMockBuilder.cs" company="ITANEO">
 // Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
 namespace Hexalith.TestMocks;
-
-using Moq;
 
 /// <summary>
 /// Interface for mock builders.
@@ -19,10 +17,4 @@ public interface IMockBuilder<out T>
     /// </summary>
     /// <returns>The mocked instance.</returns>
     T Build();
-
-    /// <summary>
-    /// Build a <see cref="Mock{T}"/> of <typeparamref name="T"/>.
-    /// </summary>
-    /// <returns>The mock of the interface.</returns>
-    IMock<T> BuildMock();
 }

--- a/src/Core/Common/Hexalith.TestMocks/LoggerBuilder.cs
+++ b/src/Core/Common/Hexalith.TestMocks/LoggerBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LoggerBuilder.cs" company="ITANEO">
+// <copyright file="LoggerBuilder.cs" company="ITANEO">
 // Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
@@ -7,7 +7,7 @@ namespace Hexalith.TestMocks;
 
 using Microsoft.Extensions.Logging;
 
-using Moq;
+using NSubstitute;
 
 /// <summary>
 /// Helper class to build a <see cref="ILogger"/> mock.
@@ -19,11 +19,5 @@ public class LoggerBuilder<T> : IMockBuilder<ILogger<T>>
     /// Build a <see cref="ILogger{T}"/>.
     /// </summary>
     /// <returns>The mocked logger.</returns>
-    public ILogger<T> Build() => BuildMock().Object;
-
-    /// <summary>
-    /// Build.
-    /// </summary>
-    /// <returns>The mock of ILogger.</returns>
-    public IMock<ILogger<T>> BuildMock() => new Mock<ILogger<T>>();
+    public ILogger<T> Build() => Substitute.For<ILogger<T>>();
 }

--- a/src/Core/Common/Hexalith.TestMocks/OptionsBuilder.cs
+++ b/src/Core/Common/Hexalith.TestMocks/OptionsBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OptionsBuilder.cs" company="ITANEO">
+// <copyright file="OptionsBuilder.cs" company="ITANEO">
 // Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
@@ -10,7 +10,7 @@ using Hexalith.Extensions.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
-using Moq;
+using NSubstitute;
 
 /// <summary>
 /// Helper class to build a <see cref="IOptions{TOptions}"/> mock.
@@ -30,23 +30,15 @@ public class OptionsBuilder<T> : IMockBuilder<IOptions<T>>
     /// Build a <see cref="IOptions{TOptions}"/>.
     /// </summary>
     /// <returns>The mocked options instance.</returns>
-    public IOptions<T> Build() => BuildMock().Object;
-
-    /// <summary>
-    /// Build.
-    /// </summary>
-    /// <returns>The options mock instance.</returns>
-    public IMock<IOptions<T>> BuildMock()
+    public IOptions<T> Build()
     {
-        Mock<IOptions<T>> mock = new();
+        IOptions<T> options = Substitute.For<IOptions<T>>();
         if (_value is not null)
         {
-            _ = mock
-                .Setup(x => x.Value)
-                .Returns(_value);
+            options.Value.Returns(_value);
         }
 
-        return mock;
+        return options;
     }
 
     /// <summary>

--- a/test/Hexalith.UnitTests/Core/Application/Applications/HexalithApplicationTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Applications/HexalithApplicationTest.cs
@@ -1,18 +1,18 @@
-﻿// <copyright file="HexalithApplicationTest.cs" company="ITANEO">
+// <copyright file="HexalithApplicationTest.cs" company="ITANEO">
 // Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
 namespace Hexalith.UnitTests.Core.Application.Applications;
 
-using FluentAssertions;
-
 using Hexalith.Application.Modules.Applications;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-using Moq;
+using NSubstitute;
+
+using Shouldly;
 
 public class HexalithApplicationTest
 {
@@ -20,38 +20,36 @@ public class HexalithApplicationTest
     public void DummyServicesFromClientModulesShouldBeAdded()
     {
         ServiceCollection services = [];
-        Mock<IConfiguration> configurationMock = new();
+        IConfiguration configuration = Substitute.For<IConfiguration>();
 
-        HexalithApplication.AddWebAppServices(services, configurationMock.Object);
+        HexalithApplication.AddWebAppServices(services, configuration);
 
         // Check that the services have been added
-        _ = services
+        services
             .Where(p => p.ImplementationType == typeof(DummyClientService))
-            .Should()
-            .HaveCount(1);
-        _ = services
+            .Count()
+            .ShouldBe(1);
+        services
             .Where(p => p.ImplementationType == typeof(DummyServerService))
-            .Should()
-            .BeEmpty();
+            .ShouldBeEmpty();
     }
 
     [Fact]
     public void DummyServicesFromServerModulesShouldBeAdded()
     {
         ServiceCollection services = [];
-        Mock<IConfiguration> configurationMock = new();
+        IConfiguration configuration = Substitute.For<IConfiguration>();
 
-        HexalithApplication.AddWebServerServices(services, configurationMock.Object);
+        HexalithApplication.AddWebServerServices(services, configuration);
 
         // Check that the services have been added
-        _ = services
+        services
             .Where(p => p.ImplementationType == typeof(DummyServerService))
-            .Should()
-            .HaveCount(1);
-        _ = services
+            .Count()
+            .ShouldBe(1);
+        services
             .Where(p => p.ImplementationType == typeof(DummyClientService))
-            .Should()
-            .BeEmpty();
+            .ShouldBeEmpty();
     }
 
     [Fact]
@@ -59,14 +57,12 @@ public class HexalithApplicationTest
         => HexalithApplication
             .WebAppApplication
             .WebAppModules
-            .Should()
-            .Contain(typeof(DummyClientModule));
+            .ShouldContain(typeof(DummyClientModule));
 
     [Fact]
     public void HexalithApplicationWebServerModuleShouldBeInstantiated()
         => HexalithApplication
             .WebServerApplication
             .WebServerModules
-            .Should()
-            .Contain(typeof(DummyServerModule));
+            .ShouldContain(typeof(DummyServerModule));
 }

--- a/test/Hexalith.UnitTests/Core/Application/Tasks/ResilientCommandProcessorTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Tasks/ResilientCommandProcessorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ResilientCommandProcessorTest.cs" company="ITANEO">
+// <copyright file="ResilientCommandProcessorTest.cs" company="ITANEO">
 // Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
@@ -6,8 +6,6 @@
 namespace Hexalith.UnitTests.Core.Application.Tasks;
 
 using System.Threading.Tasks;
-
-using FluentAssertions;
 
 using Hexalith.Application.States;
 using Hexalith.Application.Tasks;
@@ -18,82 +16,85 @@ using Hexalith.UnitTests.Core.Domain.Events;
 
 using Microsoft.Extensions.Logging;
 
-using Moq;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using Shouldly;
 
 public class ResilientCommandProcessorTest
 {
     [Fact]
     public async Task CompletedStateShouldBeValid()
     {
-        Mock<IDomainCommandDispatcher> dispatcher = new();
-        _ = dispatcher
-            .Setup(p => p.DoAsync(It.IsAny<object>(), It.IsAny<Metadata>(), null, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ExecuteCommandResult(null, [new DummyEvent1("My test response", 123)], [], false));
+        IDomainCommandDispatcher dispatcher = Substitute.For<IDomainCommandDispatcher>();
+        dispatcher
+            .DoAsync(Arg.Any<object>(), Arg.Any<Metadata>(), null, Arg.Any<CancellationToken>())
+            .Returns(new ExecuteCommandResult(null, [new DummyEvent1("My test response", 123)], [], false));
         MemoryStateProvider stateProvider = new();
         ResilientCommandProcessor processor = new(
             ResiliencyPolicy.None,
-            dispatcher.Object,
+            dispatcher,
             stateProvider,
             TimeProvider.System,
-            new Mock<ILogger<ResilientCommandProcessor>>().Object);
+            Substitute.For<ILogger<ResilientCommandProcessor>>());
         const string key = "test1";
         string stateName = nameof(TaskProcessor) + key;
         DummyCommand1 command = new("My test 1", 1);
         (TaskProcessor taskProcessor, ExecuteCommandResult result) = await processor.ProcessAsync(key, command, command.CreateMetadata(), null, CancellationToken.None);
-        _ = taskProcessor.Should().NotBeNull();
-        _ = taskProcessor.Ended.Should().BeTrue();
-        _ = taskProcessor.Status.Should().Be(TaskProcessorStatus.Completed);
-        _ = taskProcessor.Failure.Should().BeNull();
+        taskProcessor.ShouldNotBeNull();
+        taskProcessor.Ended.ShouldBeTrue();
+        taskProcessor.Status.ShouldBe(TaskProcessorStatus.Completed);
+        taskProcessor.Failure.ShouldBeNull();
 
-        _ = result.SourceEvents.Should().HaveCount(1);
-        _ = result.SourceEvents.First().Should().BeOfType<DummyEvent1>();
-        _ = stateProvider.State.Should().BeEmpty();
-        _ = stateProvider.UncommittedState.Should().NotBeEmpty();
-        _ = stateProvider.UncommittedState.Should().ContainKey(stateName);
-        _ = stateProvider.UncommittedState[stateName].Should().BeOfType<TaskProcessor>();
+        result.SourceEvents.Count().ShouldBe(1);
+        result.SourceEvents.First().ShouldBeOfType<DummyEvent1>();
+        stateProvider.State.ShouldBeEmpty();
+        stateProvider.UncommittedState.ShouldNotBeEmpty();
+        stateProvider.UncommittedState.ShouldContainKey(stateName);
+        stateProvider.UncommittedState[stateName].ShouldBeOfType<TaskProcessor>();
     }
 
     [Fact]
     public async Task TaskStatusShouldBeCancelledWhenCommandDispatcherFailsWithoutResiliency()
     {
-        Mock<IDomainCommandDispatcher> dispatcher = new();
-        _ = dispatcher
-            .Setup(p => p.DoAsync(It.IsAny<object>(), It.IsAny<Metadata>(), null, It.IsAny<CancellationToken>()))
-            .Returns(Task.FromException<ExecuteCommandResult>(new InvalidOperationException("Command execution failed.")));
+        IDomainCommandDispatcher dispatcher = Substitute.For<IDomainCommandDispatcher>();
+        dispatcher
+            .DoAsync(Arg.Any<object>(), Arg.Any<Metadata>(), null, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Command execution failed."));
         MemoryStateProvider stateProvider = new();
         ResilientCommandProcessor processor = new(
             ResiliencyPolicy.None,
-            dispatcher.Object,
+            dispatcher,
             stateProvider,
             TimeProvider.System,
-            new Mock<ILogger<ResilientCommandProcessor>>().Object);
+            Substitute.For<ILogger<ResilientCommandProcessor>>());
 
         const string key = "test1";
         string stateName = nameof(TaskProcessor) + key;
         DummyCommand1 command = new("My test 1", 1);
         (TaskProcessor taskProcessor, ExecuteCommandResult result) = await processor.ProcessAsync(key, command, command.CreateMetadata(), null, CancellationToken.None);
-        _ = taskProcessor.Should().NotBeNull();
-        _ = taskProcessor.Status.Should().Be(TaskProcessorStatus.Canceled);
-        _ = taskProcessor.History.CompletedDate.Should().BeNull();
-        _ = taskProcessor.History.ProcessingStartDate.Should().NotBeNull();
-        _ = taskProcessor.History.SuspendedDate.Should().BeNull();
-        _ = taskProcessor.History.CanceledDate.Should().NotBeNull();
-        _ = taskProcessor.Failure.Should().NotBeNull();
-        _ = stateProvider.State.Should().BeEmpty();
-        _ = stateProvider.UncommittedState.Should().NotBeEmpty();
-        _ = stateProvider.UncommittedState.Should().ContainKey(stateName);
-        _ = stateProvider.UncommittedState[stateName].Should().BeOfType<TaskProcessor>();
+        taskProcessor.ShouldNotBeNull();
+        taskProcessor.Status.ShouldBe(TaskProcessorStatus.Canceled);
+        taskProcessor.History.CompletedDate.ShouldBeNull();
+        taskProcessor.History.ProcessingStartDate.ShouldNotBeNull();
+        taskProcessor.History.SuspendedDate.ShouldBeNull();
+        taskProcessor.History.CanceledDate.ShouldNotBeNull();
+        taskProcessor.Failure.ShouldNotBeNull();
+        stateProvider.State.ShouldBeEmpty();
+        stateProvider.UncommittedState.ShouldNotBeEmpty();
+        stateProvider.UncommittedState.ShouldContainKey(stateName);
+        stateProvider.UncommittedState[stateName].ShouldBeOfType<TaskProcessor>();
         taskProcessor = stateProvider.UncommittedState[stateName] as TaskProcessor;
-        _ = taskProcessor.Should().NotBeNull();
+        taskProcessor.ShouldNotBeNull();
     }
 
     [Fact]
     public async Task TaskStatusShouldBeSuspendedWhenCommandDispatcherFailsWithResiliency()
     {
-        Mock<IDomainCommandDispatcher> dispatcher = new();
-        _ = dispatcher
-            .Setup(p => p.DoAsync(It.IsAny<object>(), It.IsAny<Metadata>(), null, It.IsAny<CancellationToken>()))
-            .Returns(Task.FromException<ExecuteCommandResult>(new InvalidOperationException("Command execution failed.")));
+        IDomainCommandDispatcher dispatcher = Substitute.For<IDomainCommandDispatcher>();
+        dispatcher
+            .DoAsync(Arg.Any<object>(), Arg.Any<Metadata>(), null, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Command execution failed."));
         MemoryStateProvider stateProvider = new();
         ResilientCommandProcessor processor = new(
             new(
@@ -103,26 +104,26 @@ public class ResilientCommandProcessorTest
                 TimeSpan.FromMilliseconds(100),
                 TimeSpan.FromDays(100),
                 false),
-            dispatcher.Object,
+            dispatcher,
             stateProvider,
             TimeProvider.System,
-            new Mock<ILogger<ResilientCommandProcessor>>().Object);
+            Substitute.For<ILogger<ResilientCommandProcessor>>());
 
         const string key = "test1";
         string stateName = nameof(TaskProcessor) + key;
         DummyCommand1 command = new("My test 1", 1);
         (TaskProcessor retry, ExecuteCommandResult result) = await processor.ProcessAsync(key, command, command.CreateMetadata(), null, CancellationToken.None);
-        _ = retry.Should().NotBeNull();
-        _ = stateProvider.State.Should().BeEmpty();
-        _ = stateProvider.UncommittedState.Should().NotBeEmpty();
-        _ = stateProvider.UncommittedState.Should().ContainKey(stateName);
-        _ = stateProvider.UncommittedState[stateName].Should().BeOfType<TaskProcessor>();
+        retry.ShouldNotBeNull();
+        stateProvider.State.ShouldBeEmpty();
+        stateProvider.UncommittedState.ShouldNotBeEmpty();
+        stateProvider.UncommittedState.ShouldContainKey(stateName);
+        stateProvider.UncommittedState[stateName].ShouldBeOfType<TaskProcessor>();
         TaskProcessor taskProcessor = stateProvider.UncommittedState[stateName] as TaskProcessor;
-        _ = taskProcessor.Status.Should().Be(TaskProcessorStatus.Suspended);
-        _ = taskProcessor.History.CompletedDate.Should().BeNull();
-        _ = taskProcessor.History.ProcessingStartDate.Should().NotBeNull();
-        _ = taskProcessor.History.SuspendedDate.Should().NotBeNull();
-        _ = taskProcessor.History.CanceledDate.Should().BeNull();
-        _ = taskProcessor.Failure.Should().NotBeNull();
+        taskProcessor.Status.ShouldBe(TaskProcessorStatus.Suspended);
+        taskProcessor.History.CompletedDate.ShouldBeNull();
+        taskProcessor.History.ProcessingStartDate.ShouldNotBeNull();
+        taskProcessor.History.SuspendedDate.ShouldNotBeNull();
+        taskProcessor.History.CanceledDate.ShouldBeNull();
+        taskProcessor.Failure.ShouldNotBeNull();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Process}.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Process}.cs
@@ -23,7 +23,7 @@
 // using Hexalith.Infrastructure.DaprRuntime.Actors;
 // using Hexalith.Infrastructure.DaprRuntime.Helpers;
 
-// using Moq;
+// using NSubstitute;
 
 ///// <summary>
 ///// Class AggregateActorTest.

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Publish}.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Publish}.cs
@@ -21,7 +21,7 @@
 // using Hexalith.Infrastructure.DaprRuntime.Actors;
 // using Hexalith.Infrastructure.DaprRuntime.Helpers;
 
-// using Moq;
+// using NSubstitute;
 
 ///// <summary>
 ///// Class AggregateActorTest.

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{submit}.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{submit}.cs
@@ -22,7 +22,7 @@
 // using Hexalith.Infrastructure.DaprRuntime.Actors;
 // using Hexalith.Infrastructure.DaprRuntime.Helpers;
 
-// using Moq;
+// using NSubstitute;
 
 ///// <summary>
 ///// Class AggregateActorTest.

--- a/test/Hexalith.UnitTests/Core/Infrastructure/States/ActorStateStoreProviderTest.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/States/ActorStateStoreProviderTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActorStateStoreProviderTest.cs" company="ITANEO">
+// <copyright file="ActorStateStoreProviderTest.cs" company="ITANEO">
 // Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
@@ -7,15 +7,13 @@ namespace Hexalith.UnitTests.Core.Infrastructure.States;
 
 using Dapr.Actors.Runtime;
 
-using FluentAssertions;
-
-using Hexalith.Application.Commands;
-using Hexalith.Applications.Commands;
 using Hexalith.Infrastructure.DaprRuntime.States;
 
 using Hexalith.UnitTests.Core.Application.Commands;
 
-using Moq;
+using NSubstitute;
+
+using Shouldly;
 
 public class ActorStateStoreProviderTest
 {
@@ -23,16 +21,13 @@ public class ActorStateStoreProviderTest
     public async Task TryGetStateShouldSucceed()
     {
         DummyCommand1 command = new("Test", 123456);
-        Mock<IActorStateManager> actorStateManager = new();
-        _ = actorStateManager
-            .Setup(p => p.TryGetStateAsync<object>("State", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConditionalValue<object>(
-                true,
-                command));
-        Mock<IDomainCommandDispatcher> dispatcher = new();
-        ActorStateStoreProvider storeProvider = new(actorStateManager.Object);
+        IActorStateManager actorStateManager = Substitute.For<IActorStateManager>();
+        actorStateManager
+            .TryGetStateAsync<object>("State", Arg.Any<CancellationToken>())
+            .Returns(new ConditionalValue<object>(true, command));
+        ActorStateStoreProvider storeProvider = new(actorStateManager);
         Hexalith.Commons.Errors.ConditionalValue<object> result = await storeProvider.TryGetStateAsync<object>("State", CancellationToken.None);
-        _ = result.HasValue.Should().BeTrue();
-        _ = result.Value.Should().BeEquivalentTo(command);
+        result.HasValue.ShouldBeTrue();
+        result.Value.ShouldBeEquivalentTo(command);
     }
 }


### PR DESCRIPTION
- Replace Moq package with NSubstitute and RichardSzalay.MockHttp
- Update IMockBuilder interface to remove Moq-specific IMock<T>
- Update LoggerBuilder, OptionsBuilder to use NSubstitute
- Update HttpClientFactoryBuilder to use MockHttp for HTTP mocking
- Migrate all test files from Moq to NSubstitute patterns:
  - Mock<T>() -> Substitute.For<T>()
  - .Setup().Returns() -> .Returns()
  - .Verify(Times.Once) -> .Received(1)
  - It.IsAny<T>() -> Arg.Any<T>()
  - It.Is<T>() -> Arg.Is<T>()
  - .Object -> (direct substitute use)