### PR TITLE
refactor(test): complete Moq to NSubstitute migration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,9 +108,8 @@
     <PackageVersion Include="Microsoft.TeamsFx" Version="2.5.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.9.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="ObjectComparator" Version="3.5.9" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />

--- a/src/Core/Common/Hexalith.TestMocks/PublicAPI.Unshipped.txt
+++ b/src/Core/Common/Hexalith.TestMocks/PublicAPI.Unshipped.txt
@@ -1,19 +1,16 @@
-﻿Hexalith.TestMocks.HttpClientFactoryBuilder
+Hexalith.TestMocks.HttpClientFactoryBuilder
 Hexalith.TestMocks.HttpClientFactoryBuilder.Build() -> System.Net.Http.IHttpClientFactory!
-Hexalith.TestMocks.HttpClientFactoryBuilder.BuildMock() -> Moq.Mock<System.Net.Http.IHttpClientFactory!>!
+Hexalith.TestMocks.HttpClientFactoryBuilder.Dispose() -> void
 Hexalith.TestMocks.HttpClientFactoryBuilder.HttpClientFactoryBuilder() -> void
 Hexalith.TestMocks.HttpClientFactoryBuilder.SetHttpMessageHandler(System.Net.Http.HttpMessageHandler! httpHandler) -> Hexalith.TestMocks.HttpClientFactoryBuilder!
 Hexalith.TestMocks.HttpClientFactoryBuilder.SetMockHttpMessageHandler(string! response) -> Hexalith.TestMocks.HttpClientFactoryBuilder!
 Hexalith.TestMocks.IMockBuilder<T>
 Hexalith.TestMocks.IMockBuilder<T>.Build() -> T!
-Hexalith.TestMocks.IMockBuilder<T>.BuildMock() -> Moq.IMock<T!>!
 Hexalith.TestMocks.LoggerBuilder<T>
 Hexalith.TestMocks.LoggerBuilder<T>.Build() -> Microsoft.Extensions.Logging.ILogger<T>!
-Hexalith.TestMocks.LoggerBuilder<T>.BuildMock() -> Moq.IMock<Microsoft.Extensions.Logging.ILogger<T>!>!
 Hexalith.TestMocks.LoggerBuilder<T>.LoggerBuilder() -> void
 Hexalith.TestMocks.OptionsBuilder<T>
 Hexalith.TestMocks.OptionsBuilder<T>.Build() -> Microsoft.Extensions.Options.IOptions<T!>!
-Hexalith.TestMocks.OptionsBuilder<T>.BuildMock() -> Moq.IMock<Microsoft.Extensions.Options.IOptions<T!>!>!
 Hexalith.TestMocks.OptionsBuilder<T>.HasValue.get -> bool
 Hexalith.TestMocks.OptionsBuilder<T>.OptionsBuilder() -> void
 Hexalith.TestMocks.OptionsBuilder<T>.WithValue(T! value) -> Hexalith.TestMocks.OptionsBuilder<T!>!


### PR DESCRIPTION
- Remove Moq and Moq.Contrib.HttpClient from central package management
- Add NSubstitute 5.3.0 to Directory.Packages.props
- Update PublicAPI.Unshipped.txt to remove stale Moq references
- RichardSzalay.MockHttp already in place for HttpClient mocking