### PR TITLE
refactor(tests): complete FluentAssertions to Shouldly migration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,9 @@
       "Bash(dotnet build:*)",
       "Bash(xxd:*)",
       "Bash(dotnet test:*)",
-      "Bash(dotnet list:*)"
+      "Bash(dotnet list:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
     ]
   }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Buses/CommandBusSettingsTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Buses/CommandBusSettingsTest.cs
@@ -5,10 +5,10 @@
 
 namespace Hexalith.UnitTests.Core.Application.Buses;
 
-using FluentAssertions;
-
 using Hexalith.Application.Buses;
 using Hexalith.TestMocks;
+
+using Shouldly;
 
 public class CommandBusSettingsTest
 {
@@ -16,7 +16,7 @@ public class CommandBusSettingsTest
     public void CheckDefaultNameIsNotNullOrEmpty()
     {
         string name = new CommandBusSettings().Name;
-        _ = name.Should().NotBeNullOrEmpty();
+        name.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class CommandBusSettingsTest
     {
         CommandBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new CommandBusSettings());
-        _ = result.IsValid.Should().BeTrue();
+        result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class CommandBusSettingsTest
             .WithValueFromConfiguration<CommandBusSettingsTest>();
         string name = settings.Build().Value.Name;
 
-        _ = name.Should().Be("my-command-bus");
+        name.ShouldBe("my-command-bus");
     }
 
     [Fact]
@@ -42,6 +42,6 @@ public class CommandBusSettingsTest
     {
         CommandBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new CommandBusSettings() { Name = string.Empty });
-        _ = result.IsValid.Should().BeFalse();
+        result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Buses/EventBusSettingsTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Buses/EventBusSettingsTest.cs
@@ -5,10 +5,10 @@
 
 namespace Hexalith.UnitTests.Core.Application.Buses;
 
-using FluentAssertions;
-
 using Hexalith.Application.Buses;
 using Hexalith.TestMocks;
+
+using Shouldly;
 
 public class EventBusSettingsTest
 {
@@ -16,7 +16,7 @@ public class EventBusSettingsTest
     public void CheckDefaultNameIsNotNullOrEmpty()
     {
         string name = new EventBusSettings().Name;
-        _ = name.Should().NotBeNullOrEmpty();
+        name.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class EventBusSettingsTest
     {
         EventBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new EventBusSettings());
-        _ = result.IsValid.Should().BeTrue();
+        result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class EventBusSettingsTest
             .WithValueFromConfiguration<EventBusSettingsTest>();
         string name = settings.Build().Value.Name;
 
-        _ = name.Should().Be("my-event-bus");
+        name.ShouldBe("my-event-bus");
     }
 
     [Fact]
@@ -42,6 +42,6 @@ public class EventBusSettingsTest
     {
         EventBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new EventBusSettings() { Name = string.Empty });
-        _ = result.IsValid.Should().BeFalse();
+        result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Buses/NotificationBusSettingsTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Buses/NotificationBusSettingsTest.cs
@@ -5,10 +5,10 @@
 
 namespace Hexalith.UnitTests.Core.Application.Buses;
 
-using FluentAssertions;
-
 using Hexalith.Application.Buses;
 using Hexalith.TestMocks;
+
+using Shouldly;
 
 public class NotificationBusSettingsTest
 {
@@ -16,7 +16,7 @@ public class NotificationBusSettingsTest
     public void CheckDefaultNameIsNotNullOrEmpty()
     {
         string name = new NotificationBusSettings().Name;
-        _ = name.Should().NotBeNullOrEmpty();
+        name.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class NotificationBusSettingsTest
     {
         NotificationBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new NotificationBusSettings());
-        _ = result.IsValid.Should().BeTrue();
+        result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class NotificationBusSettingsTest
             .WithValueFromConfiguration<NotificationBusSettingsTest>();
         string name = settings.Build().Value.Name;
 
-        _ = name.Should().Be("my-notification-bus");
+        name.ShouldBe("my-notification-bus");
     }
 
     [Fact]
@@ -42,6 +42,6 @@ public class NotificationBusSettingsTest
     {
         NotificationBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new NotificationBusSettings() { Name = string.Empty });
-        _ = result.IsValid.Should().BeFalse();
+        result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Buses/RequestBusSettingsTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Buses/RequestBusSettingsTest.cs
@@ -5,10 +5,10 @@
 
 namespace Hexalith.UnitTests.Core.Application.Buses;
 
-using FluentAssertions;
-
 using Hexalith.Application.Buses;
 using Hexalith.TestMocks;
+
+using Shouldly;
 
 public class RequestBusSettingsTest
 {
@@ -16,7 +16,7 @@ public class RequestBusSettingsTest
     public void CheckDefaultNameIsNotNullOrEmpty()
     {
         string name = new RequestBusSettings().Name;
-        _ = name.Should().NotBeNullOrEmpty();
+        name.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class RequestBusSettingsTest
     {
         RequestBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new RequestBusSettings());
-        _ = result.IsValid.Should().BeTrue();
+        result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class RequestBusSettingsTest
             .WithValueFromConfiguration<RequestBusSettingsTest>();
         string name = settings.Build().Value.Name;
 
-        _ = name.Should().Be("my-request-bus");
+        name.ShouldBe("my-request-bus");
     }
 
     [Fact]
@@ -42,6 +42,6 @@ public class RequestBusSettingsTest
     {
         RequestBusSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new RequestBusSettings() { Name = string.Empty });
-        _ = result.IsValid.Should().BeFalse();
+        result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Commands/BaseCommandTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Commands/BaseCommandTest.cs
@@ -5,11 +5,12 @@
 
 namespace Hexalith.UnitTests.Core.Application.Commands;
 
+using System.Runtime.Serialization;
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.PolymorphicSerializations;
+
+using Shouldly;
 
 public class BaseCommandTest
 {
@@ -19,7 +20,12 @@ public class BaseCommandTest
     public void DataContractSerializeAndDeserializeShouldReturnSameObject()
     {
         DummyCommand1 original = new("IB2343213FR", 1256);
-        _ = original.Should().BeDataContractSerializable();
+        DataContractSerializer serializer = new(typeof(DummyCommand1));
+        using MemoryStream stream = new();
+        serializer.WriteObject(stream, original);
+        stream.Position = 0;
+        DummyCommand1 result = (DummyCommand1)serializer.ReadObject(stream);
+        result.ShouldBeEquivalentTo(original);
     }
 
     [Fact]
@@ -28,9 +34,9 @@ public class BaseCommandTest
         DummyCommand1 original = new("IB2343213FR", 655463);
         string json = JsonSerializer.Serialize<Polymorphic>(original, PolymorphicHelper.DefaultJsonSerializerOptions);
         object result = JsonSerializer.Deserialize<Polymorphic>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeOfType<DummyCommand1>();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<DummyCommand1>();
+        result.ShouldBeEquivalentTo(original);
     }
 
     [Fact]
@@ -38,8 +44,8 @@ public class BaseCommandTest
     {
         DummyCommand1 original = new("IB2343213FR", 655463);
         string json = JsonSerializer.Serialize<Polymorphic>(original, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = json.Should().NotBeNull();
-        _ = json.Should().Contain($"\"{PolymorphicHelper.Discriminator}\": \"{nameof(DummyCommand1)}\"");
+        json.ShouldNotBeNull();
+        json.ShouldContain($"\"{PolymorphicHelper.Discriminator}\": \"{nameof(DummyCommand1)}\"");
     }
 
     [Fact]
@@ -48,7 +54,7 @@ public class BaseCommandTest
         DummyCommand1 original = new("IB2343213FR", 1256);
         string json = JsonSerializer.Serialize(original);
         DummyCommand1 result = JsonSerializer.Deserialize<DummyCommand1>(json);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(original);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Metadatas/MessageMetadataTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Metadatas/MessageMetadataTest.cs
@@ -7,10 +7,10 @@ namespace Hexalith.UnitTests.Core.Application.Metadatas;
 
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.Commons.Metadatas;
 using Hexalith.UnitTests.Core.Domain.Messages;
+
+using Shouldly;
 
 public class MessageMetadataTest
 {
@@ -20,31 +20,31 @@ public class MessageMetadataTest
         MessageMetadata meta = new("ID123", "Message 123", 123, new DomainMetadata("101", "Dummy"), TimeProvider.System.GetLocalNow());
         string json = JsonSerializer.Serialize(meta);
         Metadata result = JsonSerializer.Deserialize<Metadata>(json);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(result);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(result);
     }
 
     [Fact]
     public void MetadataShouldContainMessageNameAndVersion1()
     {
         MessageMetadata meta = new MyDummyMessage("123", "Hello", 124).CreateMessageMetadata(TimeProvider.System.GetLocalNow());
-        _ = meta.Name.Should().Be(nameof(MyDummyMessage));
-        _ = meta.Version.Should().Be(1);
+        meta.Name.ShouldBe(nameof(MyDummyMessage));
+        meta.Version.ShouldBe(1);
     }
 
     [Fact]
     public void MetadataShouldContainMessageNameAndVersionInAttribute()
     {
         MessageMetadata meta = new MyDummyMessage3("123", "Hello", 124).CreateMessageMetadata(TimeProvider.System.GetLocalNow());
-        _ = meta.Name.Should().Be("MyMessage");
-        _ = meta.Version.Should().Be(3);
+        meta.Name.ShouldBe("MyMessage");
+        meta.Version.ShouldBe(3);
     }
 
     [Fact]
     public void MetadataShouldContainMessageVersionInAttribute()
     {
         MessageMetadata meta = new MyDummyMessage2("123", "Hello", 124).CreateMessageMetadata(TimeProvider.System.GetLocalNow());
-        _ = meta.Name.Should().Be(nameof(MyDummyMessage2));
-        _ = meta.Version.Should().Be(2);
+        meta.Name.ShouldBe(nameof(MyDummyMessage2));
+        meta.Version.ShouldBe(2);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Metadatas/MessageStateTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Metadatas/MessageStateTest.cs
@@ -8,15 +8,13 @@ namespace Hexalith.UnitTests.Core.Application.Metadatas;
 using System;
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.Applications.States;
 using Hexalith.Commons.Metadatas;
 using Hexalith.Commons.Strings;
 using Hexalith.PolymorphicSerializations;
 using Hexalith.UnitTests.Core.Domain.Messages;
 
-using Xunit;
+using Shouldly;
 
 public class MessageStateTest
 {
@@ -40,10 +38,13 @@ public class MessageStateTest
                 ["scope1", "scope9"]));
         MessageState state = new(message, meta);
         string json = JsonSerializer.Serialize(state, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = json.Should().NotBeNullOrEmpty();
+        json.ShouldNotBeNullOrEmpty();
         MessageState result = JsonSerializer.Deserialize<MessageState>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(state);
+        result.ShouldNotBeNull();
+
+        // Compare by re-serializing (avoids array/list type mismatch from polymorphic serialization)
+        string resultJson = JsonSerializer.Serialize(result, PolymorphicHelper.DefaultJsonSerializerOptions);
+        resultJson.ShouldBe(json);
     }
 
     [Fact]
@@ -64,12 +65,12 @@ public class MessageStateTest
                 ["scope1", "scope9"]));
         MessageState state = new(message, meta);
         string json = JsonSerializer.Serialize(state, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = json.Should().NotBeNullOrEmpty();
-        _ = json.Should().Contain($"MyMessageV3");
-        _ = json.Should().Contain($"\"{nameof(meta.Message.Name)}\": \"MyMessage\"");
-        _ = json.Should().Contain($"\"{nameof(meta.Message.Version)}\": 3");
-        _ = json.Should().Contain($"\"{nameof(meta.Message.Id)}\": \"{meta.Message.Id}\"");
-        _ = json.Should().Contain(message.Value.ToInvariantString());
+        json.ShouldNotBeNullOrEmpty();
+        json.ShouldContain($"MyMessageV3");
+        json.ShouldContain($"\"{nameof(meta.Message.Name)}\": \"MyMessage\"");
+        json.ShouldContain($"\"{nameof(meta.Message.Version)}\": 3");
+        json.ShouldContain($"\"{nameof(meta.Message.Id)}\": \"{meta.Message.Id}\"");
+        json.ShouldContain(message.Value.ToInvariantString());
     }
 
     [Fact]
@@ -90,13 +91,13 @@ public class MessageStateTest
                 ["scope1", "scope9"]));
         MessageState state = new(message, meta);
         string json = JsonSerializer.Serialize(state, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = state.Message.Should().Contain($"MyDummyMessage2V2");
-        _ = json.Should().NotBeNullOrEmpty();
-        _ = json.Should().Contain($"MyDummyMessage2V2");
-        _ = json.Should().Contain($"\"{nameof(meta.Message.Version)}\": 2");
-        _ = json.Should().Contain($"\"{nameof(meta.Message.Id)}\": \"{meta.Message.Id}\"");
-        _ = json.Should().Contain(message.Name);
-        _ = json.Should().Contain(message.Value.ToInvariantString());
+        state.Message.ShouldContain($"MyDummyMessage2V2");
+        json.ShouldNotBeNullOrEmpty();
+        json.ShouldContain($"MyDummyMessage2V2");
+        json.ShouldContain($"\"{nameof(meta.Message.Version)}\": 2");
+        json.ShouldContain($"\"{nameof(meta.Message.Id)}\": \"{meta.Message.Id}\"");
+        json.ShouldContain(message.Name);
+        json.ShouldContain(message.Value.ToInvariantString());
     }
 
     [Fact]
@@ -117,10 +118,13 @@ public class MessageStateTest
                 ["scope1", "scope9"]));
         MessageState state = new(message, meta);
         string json = JsonSerializer.Serialize(state, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = json.Should().NotBeNullOrEmpty();
+        json.ShouldNotBeNullOrEmpty();
         MessageState result = JsonSerializer.Deserialize<MessageState>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(state);
+        result.ShouldNotBeNull();
+
+        // Compare by re-serializing (avoids array/list type mismatch from polymorphic serialization)
+        string resultJson = JsonSerializer.Serialize(result, PolymorphicHelper.DefaultJsonSerializerOptions);
+        resultJson.ShouldBe(json);
     }
 
     [Fact]
@@ -141,9 +145,12 @@ public class MessageStateTest
                 ["scope1", "scope9"]));
         MessageState state = new(message, meta);
         string json = JsonSerializer.Serialize(state, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = json.Should().NotBeNullOrEmpty();
+        json.ShouldNotBeNullOrEmpty();
         MessageState result = JsonSerializer.Deserialize<MessageState>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(state);
+        result.ShouldNotBeNull();
+
+        // Compare by re-serializing (avoids array/list type mismatch from polymorphic serialization)
+        string resultJson = JsonSerializer.Serialize(result, PolymorphicHelper.DefaultJsonSerializerOptions);
+        resultJson.ShouldBe(json);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Metadatas/MetadataTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Metadatas/MetadataTest.cs
@@ -7,9 +7,9 @@ namespace Hexalith.UnitTests.Core.Application.Metadatas;
 
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.Commons.Metadatas;
+
+using Shouldly;
 
 public class MetadataTest
 {
@@ -21,8 +21,8 @@ public class MetadataTest
         Metadata meta = GetMetadata();
         string json = JsonSerializer.Serialize(meta);
         Metadata result = JsonSerializer.Deserialize<Metadata>(json);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(result);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(result);
     }
 
     [Fact]
@@ -30,8 +30,8 @@ public class MetadataTest
     {
         Metadata meta = GetMetadata();
         string json = JsonSerializer.Serialize(meta);
-        _ = json.Should().NotBeNull();
-        _ = json.Should().Contain(meta.Message.Id);
+        json.ShouldNotBeNull();
+        json.ShouldContain(meta.Message.Id);
     }
 
     private static Metadata GetMetadata()

--- a/test/Hexalith.UnitTests/Core/Application/Requests/BaseRequestTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Requests/BaseRequestTest.cs
@@ -7,9 +7,9 @@ namespace Hexalith.UnitTests.Core.Application.Requests;
 
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.PolymorphicSerializations;
+
+using Shouldly;
 
 public class BaseRequestTest
 {
@@ -21,9 +21,9 @@ public class BaseRequestTest
         DummyRequest1 original = new("IB2343213FR", 655463);
         string json = JsonSerializer.Serialize<Polymorphic>(original, PolymorphicHelper.DefaultJsonSerializerOptions);
         object result = JsonSerializer.Deserialize<Polymorphic>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeOfType<DummyRequest1>();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<DummyRequest1>();
+        result.ShouldBeEquivalentTo(original);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class BaseRequestTest
         DummyRequest1 original = new("IB2343213FR", 1256);
         string json = JsonSerializer.Serialize(original, PolymorphicHelper.DefaultJsonSerializerOptions);
         DummyRequest1 result = JsonSerializer.Deserialize<DummyRequest1>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(original);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/States/MemoryStateProviderTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/States/MemoryStateProviderTest.cs
@@ -5,12 +5,12 @@
 
 namespace Hexalith.UnitTests.Core.Application.States;
 
-using FluentAssertions;
-
 using Hexalith.Application.States;
 using Hexalith.Commons.Errors;
 using Hexalith.Commons.Objects;
 using Hexalith.Extensions.Common;
+
+using Shouldly;
 
 public class MemoryStateProviderTest
 {
@@ -20,8 +20,8 @@ public class MemoryStateProviderTest
         MemoryStateProvider provider = new();
         DummyState state = new("5354323", 123, "one two three");
         await provider.SetStateAsync(state.IdempotencyId, state, CancellationToken.None);
-        _ = provider.UncommittedState.Should().HaveCount(1);
-        _ = provider.UncommittedState[state.IdempotencyId].Should().Be(state);
+        provider.UncommittedState.Count.ShouldBe(1);
+        provider.UncommittedState[state.IdempotencyId].ShouldBe(state);
     }
 
     [Fact]
@@ -30,8 +30,8 @@ public class MemoryStateProviderTest
         DummyState state = new("5354323", 123, "one two three");
         MemoryStateProvider provider = new(new Dictionary<string, object> { { state.IdempotencyId, state } });
         DummyState result = await provider.GetStateAsync<DummyState>(state.IdempotencyId, CancellationToken.None);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(state);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(state);
     }
 
     [Fact]
@@ -40,9 +40,9 @@ public class MemoryStateProviderTest
         DummyState state = new("5354323", 123, "one two three");
         MemoryStateProvider provider = new(new Dictionary<string, object> { { state.IdempotencyId, state } });
         ConditionalValue<DummyState> result = await provider.TryGetStateAsync<DummyState>(state.IdempotencyId, CancellationToken.None);
-        _ = result.Should().NotBeNull();
-        _ = result.HasValue.Should().BeTrue();
-        _ = result.Value.Should().BeEquivalentTo(state);
+        result.ShouldNotBeNull();
+        result.HasValue.ShouldBeTrue();
+        result.Value.ShouldBeEquivalentTo(state);
     }
 
     [Fact]
@@ -51,9 +51,9 @@ public class MemoryStateProviderTest
         DummyState state = new("5354323", 123, "one two three");
         MemoryStateProvider provider = new(new Dictionary<string, object> { { state.IdempotencyId, state } });
         ConditionalValue<DummyState> result = await provider.TryGetStateAsync<DummyState>(state.IdempotencyId, CancellationToken.None);
-        _ = result.Should().NotBeNull();
-        _ = result.HasValue.Should().BeTrue();
-        _ = result.Value.Should().BeEquivalentTo(state);
+        result.ShouldNotBeNull();
+        result.HasValue.ShouldBeTrue();
+        result.Value.ShouldBeEquivalentTo(state);
     }
 
     private record DummyState(string IdempotencyId, int Id, string Name) : IIdempotent

--- a/test/Hexalith.UnitTests/Core/Application/States/StateStoreSettingsTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/States/StateStoreSettingsTest.cs
@@ -5,7 +5,7 @@
 
 namespace Hexalith.UnitTests.Core.Application.States;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Application.States;
 using Hexalith.TestMocks;
@@ -16,7 +16,7 @@ public class StateStoreSettingsTest
     public void CheckDefaultNameIsNotNullOrEmpty()
     {
         string name = new StateStoreSettings().Name;
-        _ = name.Should().NotBeNullOrEmpty();
+        name.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class StateStoreSettingsTest
     {
         StateStoreSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new StateStoreSettings());
-        _ = result.IsValid.Should().BeTrue();
+        result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class StateStoreSettingsTest
             .WithValueFromConfiguration<StateStoreSettingsTest>();
         string name = settings.Build().Value.Name;
 
-        _ = name.Should().Be("my-statestore");
+        name.ShouldBe("my-statestore");
     }
 
     [Fact]
@@ -42,6 +42,6 @@ public class StateStoreSettingsTest
     {
         StateStoreSettingsValidator validator = new();
         FluentValidation.Results.ValidationResult result = validator.Validate(new StateStoreSettings() { Name = string.Empty });
-        _ = result.IsValid.Should().BeFalse();
+        result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/Tasks/TaskProcessingHistoryTest.cs
+++ b/test/Hexalith.UnitTests/Core/Application/Tasks/TaskProcessingHistoryTest.cs
@@ -7,7 +7,7 @@ namespace Hexalith.UnitTests.Core.Application.Tasks;
 
 using System;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Application.Tasks;
 
@@ -18,11 +18,11 @@ public class TaskProcessingHistoryTest
     {
         TaskProcessingHistory history = new TaskProcessingHistory(DateTimeOffset.UtcNow, null, null, null, null)
             .Canceled();
-        _ = history.CreatedDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1));
-        _ = history.CanceledDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1));
-        _ = history.CompletedDate.Should().BeNull();
-        _ = history.ProcessingStartDate.Should().BeNull();
-        _ = history.SuspendedDate.Should().BeNull();
+        (DateTimeOffset.UtcNow - history.CreatedDate).TotalSeconds.ShouldBeLessThan(1);
+        (DateTimeOffset.UtcNow - history.CanceledDate.Value).TotalSeconds.ShouldBeLessThan(1);
+        history.CompletedDate.ShouldBeNull();
+        history.ProcessingStartDate.ShouldBeNull();
+        history.SuspendedDate.ShouldBeNull();
     }
 
     [Fact]
@@ -30,22 +30,22 @@ public class TaskProcessingHistoryTest
     {
         TaskProcessingHistory history = new TaskProcessingHistory(DateTimeOffset.UtcNow, null, null, null, null)
             .Completed();
-        _ = history.CreatedDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1));
-        _ = history.CompletedDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1));
-        _ = history.ProcessingStartDate.Should().BeNull();
-        _ = history.CanceledDate.Should().BeNull();
-        _ = history.SuspendedDate.Should().BeNull();
+        (DateTimeOffset.UtcNow - history.CreatedDate).TotalSeconds.ShouldBeLessThan(1);
+        (DateTimeOffset.UtcNow - history.CompletedDate.Value).TotalSeconds.ShouldBeLessThan(1);
+        history.ProcessingStartDate.ShouldBeNull();
+        history.CanceledDate.ShouldBeNull();
+        history.SuspendedDate.ShouldBeNull();
     }
 
     [Fact]
     public void CreatedHistoryDateShouldBeNow()
     {
         TaskProcessingHistory history = new(DateTimeOffset.UtcNow, null, null, null, null);
-        _ = history.CreatedDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1));
-        _ = history.CanceledDate.Should().BeNull();
-        _ = history.CompletedDate.Should().BeNull();
-        _ = history.ProcessingStartDate.Should().BeNull();
-        _ = history.SuspendedDate.Should().BeNull();
+        (DateTimeOffset.UtcNow - history.CreatedDate).TotalSeconds.ShouldBeLessThan(1);
+        history.CanceledDate.ShouldBeNull();
+        history.CompletedDate.ShouldBeNull();
+        history.ProcessingStartDate.ShouldBeNull();
+        history.SuspendedDate.ShouldBeNull();
     }
 
     [Fact]
@@ -53,10 +53,10 @@ public class TaskProcessingHistoryTest
     {
         TaskProcessingHistory history = new TaskProcessingHistory(DateTimeOffset.UtcNow, null, null, null, null)
             .ProcessingStarted();
-        _ = history.CreatedDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(100));
-        _ = history.ProcessingStartDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(10));
-        _ = history.CompletedDate.Should().BeNull();
-        _ = history.CanceledDate.Should().BeNull();
-        _ = history.SuspendedDate.Should().BeNull();
+        (DateTimeOffset.UtcNow - history.CreatedDate).TotalMilliseconds.ShouldBeLessThan(100);
+        (DateTimeOffset.UtcNow - history.ProcessingStartDate.Value).TotalMilliseconds.ShouldBeLessThan(10);
+        history.CompletedDate.ShouldBeNull();
+        history.CanceledDate.ShouldBeNull();
+        history.SuspendedDate.ShouldBeNull();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/TopologicalSort/Ordering.cs
+++ b/test/Hexalith.UnitTests/Core/Application/TopologicalSort/Ordering.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Application.TopologicalSorting;
 
@@ -32,15 +32,15 @@ public class Ordering
 
         IEnumerable<IEnumerable<OrderedProcess>> s = g.CalculateSort();
 
-        _ = s.Skip(0).First().Count().Should().Be(1);
-        _ = s.Skip(0).First().First().Should().Be(a);
+        s.Skip(0).First().Count().ShouldBe(1);
+        s.Skip(0).First().First().ShouldBe(a);
 
-        _ = s.Skip(1).First().Count().Should().Be(2);
-        _ = s.Skip(1).First().Should().Contain(b1);
-        _ = s.Skip(1).First().Should().Contain(b2);
+        s.Skip(1).First().Count().ShouldBe(2);
+        s.Skip(1).First().ShouldContain(b1);
+        s.Skip(1).First().ShouldContain(b2);
 
-        _ = s.Skip(2).First().Count().Should().Be(1);
-        _ = s.Skip(2).First().First().Should().Be(c);
+        s.Skip(2).First().Count().ShouldBe(1);
+        s.Skip(2).First().First().ShouldBe(c);
     }
 
     /// <summary>
@@ -61,14 +61,14 @@ public class Ordering
 
         IEnumerable<IEnumerable<OrderedProcess>> s = g.CalculateSort();
 
-        _ = s.Skip(0).First().Count().Should().Be(1);
-        _ = s.Skip(0).First().First().Should().Be(a);
+        s.Skip(0).First().Count().ShouldBe(1);
+        s.Skip(0).First().First().ShouldBe(a);
 
-        _ = s.Skip(1).First().Count().Should().Be(1);
-        _ = s.Skip(1).First().First().Should().Be(b);
+        s.Skip(1).First().Count().ShouldBe(1);
+        s.Skip(1).First().First().ShouldBe(b);
 
-        _ = s.Skip(2).First().Count().Should().Be(1);
-        _ = s.Skip(2).First().First().Should().Be(c);
+        s.Skip(2).First().Count().ShouldBe(1);
+        s.Skip(2).First().First().ShouldBe(c);
     }
 
     /// <summary>
@@ -87,14 +87,14 @@ public class Ordering
 
         IEnumerable<IEnumerable<OrderedProcess>> s = g.CalculateSort();
 
-        _ = s.Skip(0).First().Count().Should().Be(1);
-        _ = s.Skip(0).First().First().Should().Be(a);
+        s.Skip(0).First().Count().ShouldBe(1);
+        s.Skip(0).First().First().ShouldBe(a);
 
-        _ = s.Skip(1).First().Count().Should().Be(1);
-        _ = s.Skip(1).First().First().Should().Be(b);
+        s.Skip(1).First().Count().ShouldBe(1);
+        s.Skip(1).First().First().ShouldBe(b);
 
-        _ = s.Skip(2).First().Count().Should().Be(1);
-        _ = s.Skip(2).First().First().Should().Be(c);
+        s.Skip(2).First().Count().ShouldBe(1);
+        s.Skip(2).First().First().ShouldBe(c);
     }
 
     /// <summary>
@@ -117,7 +117,7 @@ public class Ordering
         _ = a.Before(b1, b2).Before(c1, c2, c3, c4).Before(d).Before(b1);
 
         Action calc = () => g.CalculateSort();
-        _ = calc.Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(calc);
     }
 
     /// <summary>
@@ -141,21 +141,21 @@ public class Ordering
 
         IEnumerable<IEnumerable<OrderedProcess>> s = g.CalculateSort();
 
-        _ = s.Skip(0).First().Count().Should().Be(1);
-        _ = s.Skip(0).First().First().Should().Be(a);
+        s.Skip(0).First().Count().ShouldBe(1);
+        s.Skip(0).First().First().ShouldBe(a);
 
-        _ = s.Skip(1).First().Count().Should().Be(2);
-        _ = s.Skip(1).First().Should().Contain(b1);
-        _ = s.Skip(1).First().Should().Contain(b2);
+        s.Skip(1).First().Count().ShouldBe(2);
+        s.Skip(1).First().ShouldContain(b1);
+        s.Skip(1).First().ShouldContain(b2);
 
-        _ = s.Skip(2).First().Count().Should().Be(4);
-        _ = s.Skip(2).First().Should().Contain(c1);
-        _ = s.Skip(2).First().Should().Contain(c2);
-        _ = s.Skip(2).First().Should().Contain(c3);
-        _ = s.Skip(2).First().Should().Contain(c4);
+        s.Skip(2).First().Count().ShouldBe(4);
+        s.Skip(2).First().ShouldContain(c1);
+        s.Skip(2).First().ShouldContain(c2);
+        s.Skip(2).First().ShouldContain(c3);
+        s.Skip(2).First().ShouldContain(c4);
 
-        _ = s.Skip(3).First().Count().Should().Be(1);
-        _ = s.Skip(3).First().First().Should().Be(d);
+        s.Skip(3).First().Count().ShouldBe(1);
+        s.Skip(3).First().First().ShouldBe(d);
     }
 
     /// <summary>
@@ -173,6 +173,6 @@ public class Ordering
         _ = b.Before(a);
 
         Action calc = () => g.CalculateSort();
-        _ = calc.Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(calc);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Application/TopologicalSort/Resources.cs
+++ b/test/Hexalith.UnitTests/Core/Application/TopologicalSort/Resources.cs
@@ -8,7 +8,7 @@ namespace Hexalith.UnitTests.Core.Application.TopologicalSort;
 using System.Collections.Generic;
 using System.Linq;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Application.TopologicalSorting;
 
@@ -36,18 +36,18 @@ public class Resources
 
         IEnumerable<IEnumerable<OrderedProcess>> s = g.CalculateSort();
 
-        _ = s.Count().Should().Be(3);
+        s.Count().ShouldBe(3);
 
-        _ = s.Skip(0).First().Count().Should().Be(1);
-        _ = s.Skip(0).First().First().Should().Be(a);
+        s.Skip(0).First().Count().ShouldBe(1);
+        s.Skip(0).First().First().ShouldBe(a);
 
-        _ = s.Skip(1).First().Count().Should().Be(1);
-        _ = (s.Skip(1).First().First() == b || s.Skip(1).First().First() == c).Should().BeTrue();
+        s.Skip(1).First().Count().ShouldBe(1);
+        (s.Skip(1).First().First() == b || s.Skip(1).First().First() == c).ShouldBeTrue();
 
-        _ = s.Skip(0).First().Count().Should().Be(1);
-        _ = (s.Skip(2).First().First() == b || s.Skip(2).First().First() == c).Should().BeTrue();
+        s.Skip(0).First().Count().ShouldBe(1);
+        (s.Skip(2).First().First() == b || s.Skip(2).First().First() == c).ShouldBeTrue();
 
-        _ = s.Skip(1).First().First().Should().NotBe(s.Skip(2).First().First());
+        s.Skip(1).First().First().ShouldNotBe(s.Skip(2).First().First());
     }
 
     /// <summary>
@@ -75,14 +75,14 @@ public class Resources
         IEnumerable<IEnumerable<OrderedProcess>> s = g.CalculateSort();
 
         // check that A comes first
-        _ = s.Skip(0).First().Count().Should().Be(1);
-        _ = s.Skip(0).First().First().Should().Be(a);
+        s.Skip(0).First().Count().ShouldBe(1);
+        s.Skip(0).First().First().ShouldBe(a);
 
         // check that D comes last
-        _ = s.Skip(4).First().Count().Should().Be(1);
-        _ = s.Skip(4).First().First().Should().Be(d);
+        s.Skip(4).First().Count().ShouldBe(1);
+        s.Skip(4).First().First().ShouldBe(d);
 
         // check that no set contains both c1 and c3
-        _ = s.Count(set => set.Contains(c1) && set.Contains(c3)).Should().Be(0);
+        s.Count(set => set.Contains(c1) && set.Contains(c3)).ShouldBe(0);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Common/Common/AreSameEnumerationTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Common/AreSameEnumerationTest.cs
@@ -5,7 +5,7 @@
 
 namespace Hexalith.UnitTests.Core.Common.Common;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Extensions.Helpers;
 
@@ -24,8 +24,8 @@ public class AreSameEnumerationTest
             [100] = new DummyEquatable(),
             [101] = new DummyEquatable() { Property3 = 11 },
         };
-        _ = a.AreSameDictionary(b).Should().BeFalse();
-        _ = a.AreSame(b).Should().BeFalse();
+        a.AreSameDictionary(b).ShouldBeFalse();
+        a.AreSame(b).ShouldBeFalse();
     }
 
     [Fact]
@@ -41,8 +41,8 @@ public class AreSameEnumerationTest
             [100] = new DummyEquatable(),
             [101] = new DummyEquatable() { Property3 = 10 },
         };
-        _ = a.AreSameDictionary(b).Should().BeTrue();
-        _ = a.AreSame(b).Should().BeTrue();
+        a.AreSameDictionary(b).ShouldBeTrue();
+        a.AreSame(b).ShouldBeTrue();
     }
 
     [Fact]
@@ -50,8 +50,8 @@ public class AreSameEnumerationTest
     {
         List<DummyEquatable> a = [new DummyEquatable(), new DummyEquatable() { Property3 = 10 }];
         List<DummyEquatable> b = [new DummyEquatable(), new DummyEquatable() { Property3 = 11 }];
-        _ = a.AreSameEnumeration(b).Should().BeFalse();
-        _ = a.AreSame(b).Should().BeFalse();
+        a.AreSameEnumeration(b).ShouldBeFalse();
+        a.AreSame(b).ShouldBeFalse();
     }
 
     [Fact]
@@ -59,8 +59,8 @@ public class AreSameEnumerationTest
     {
         List<DummyEquatable> a = [new DummyEquatable(), new DummyEquatable() { Property3 = 10 }];
         List<DummyEquatable> b = [new DummyEquatable(), new DummyEquatable() { Property3 = 10 }];
-        _ = a.AreSameEnumeration(b).Should().BeTrue();
-        _ = a.AreSame(b).Should().BeTrue();
+        a.AreSameEnumeration(b).ShouldBeTrue();
+        a.AreSame(b).ShouldBeTrue();
     }
 
     [Fact]
@@ -68,8 +68,8 @@ public class AreSameEnumerationTest
     {
         Dictionary<int, string> a = new() { [10] = "Hello", [11] = "world" };
         Dictionary<int, string> b = new() { [10] = "Hello", [11] = "world*" };
-        _ = a.AreSameDictionary(b).Should().BeFalse();
-        _ = a.AreSame(b).Should().BeFalse();
+        a.AreSameDictionary(b).ShouldBeFalse();
+        a.AreSame(b).ShouldBeFalse();
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public class AreSameEnumerationTest
     {
         Dictionary<int, string> a = new() { [10] = "Hello", [11] = "world" };
         Dictionary<int, string> b = new() { [10] = "Hello", [11] = "world" };
-        _ = a.AreSameDictionary(b).Should().BeTrue();
-        _ = a.AreSame(b).Should().BeTrue();
+        a.AreSameDictionary(b).ShouldBeTrue();
+        a.AreSame(b).ShouldBeTrue();
     }
 
     [Fact]
@@ -86,8 +86,8 @@ public class AreSameEnumerationTest
     {
         List<string> a = ["Hello", "World"];
         List<string> b = ["Hello", "World*"];
-        _ = a.AreSameEnumeration(b).Should().BeFalse();
-        _ = a.AreSame(b).Should().BeFalse();
+        a.AreSameEnumeration(b).ShouldBeFalse();
+        a.AreSame(b).ShouldBeFalse();
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class AreSameEnumerationTest
     {
         List<string> a = ["Hello", "World"];
         List<string> b = ["Hello", "World"];
-        _ = a.AreSameEnumeration(b).Should().BeTrue();
-        _ = a.AreSame(b).Should().BeTrue();
+        a.AreSameEnumeration(b).ShouldBeTrue();
+        a.AreSame(b).ShouldBeTrue();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Common/Common/AreSameTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Common/AreSameTest.cs
@@ -5,7 +5,7 @@
 
 namespace Hexalith.UnitTests.Core.Common.Common;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Extensions.Helpers;
 
@@ -16,7 +16,7 @@ public class AreSameTest
     {
         DummyEmbeddedEquatable a = new();
         DummyEmbeddedEquatable b = new() { Property4 = a.Property4 };
-        _ = a.AreSame(b).Should().BeTrue();
+        a.AreSame(b).ShouldBeTrue();
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class AreSameTest
     {
         DummyEquatable a = new();
         DummyEquatable b = new() { Property2 = "Hello" };
-        _ = a.AreSame(b).Should().BeFalse();
+        a.AreSame(b).ShouldBeFalse();
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class AreSameTest
     {
         DummyEquatable a = new();
         DummyEquatable b = new();
-        _ = a.AreSame(b).Should().BeTrue();
+        a.AreSame(b).ShouldBeTrue();
     }
 
     [Fact]
@@ -40,13 +40,13 @@ public class AreSameTest
     {
         DummyNonEquatable a = new();
         DummyNonEquatable b = new();
-        _ = a.AreSame(b).Should().BeFalse();
+        a.AreSame(b).ShouldBeFalse();
     }
 
     [Fact]
     public void NonEquatableAreSameShouldReturnTrue()
     {
         DummyNonEquatable a = new();
-        _ = a.AreSame(a).Should().BeTrue();
+        a.AreSame(a).ShouldBeTrue();
     }
 }

--- a/test/Hexalith.UnitTests/Core/Common/Configuration/ConfigureSettingsTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Configuration/ConfigureSettingsTest.cs
@@ -5,7 +5,7 @@
 
 namespace Hexalith.UnitTests.Core.Common.Configuration;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.TestMocks;
 
@@ -29,6 +29,9 @@ public class ConfigureSettingsTest
         Microsoft.Extensions.Options.IOptions<TestSettings> settings = new OptionsBuilder<TestSettings>()
             .WithValueFromConfiguration<ConfigureSettingsTest>()
             .Build();
-        _ = settings.Value.Should().BeEquivalentTo(expected);
+        settings.Value.TestLong.ShouldBe(expected.TestLong);
+        settings.Value.TestString.ShouldBe(expected.TestString);
+        settings.Value.TestClass.TestLong.ShouldBe(expected.TestClass.TestLong);
+        settings.Value.TestClass.TestString.ShouldBe(expected.TestClass.TestString);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Common/Exceptions/SettingsExceptionTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Exceptions/SettingsExceptionTest.cs
@@ -5,7 +5,7 @@
 
 namespace Hexalith.UnitTests.Core.Common.Exceptions;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Extensions.Configuration;
 
@@ -32,10 +32,10 @@ public class SettingsExceptionTest
     {
         IOptions<DummySettings> options = Options.Create<DummySettings>(new DummySettings());
         Action a = () => SettingsException<DummySettings>.ThrowIfUndefined(options.Value.Name);
-        _ = a
-            .Should()
-            .Throw<SettingsException<DummySettings>>()
-            .Where(p => p.ParamName == "options.Value.Name" && p.Message.Contains("Dummy") && p.Message.Contains("Name"));
+        SettingsException<DummySettings> ex = Should.Throw<SettingsException<DummySettings>>(a);
+        ex.ParamName.ShouldBe("options.Value.Name");
+        ex.Message.ShouldContain("Dummy");
+        ex.Message.ShouldContain("Name");
     }
 
     [Fact]
@@ -43,10 +43,10 @@ public class SettingsExceptionTest
     {
         DummySettings settings = new();
         Action a = () => SettingsException<DummySettings>.ThrowIfUndefined(settings.Name);
-        _ = a
-            .Should()
-            .Throw<SettingsException<DummySettings>>()
-            .Where(p => p.ParamName == "settings.Name" && p.Message.Contains("Dummy") && p.Message.Contains("Name"));
+        SettingsException<DummySettings> ex = Should.Throw<SettingsException<DummySettings>>(a);
+        ex.ParamName.ShouldBe("settings.Name");
+        ex.Message.ShouldContain("Dummy");
+        ex.Message.ShouldContain("Name");
     }
 
     [Fact]
@@ -54,10 +54,10 @@ public class SettingsExceptionTest
     {
         DummySettings settings = new() { SubConfig = new SubConfiguration() };
         Action a = () => SettingsException<DummySettings>.ThrowIfUndefined(settings.SubConfig.Hello);
-        _ = a
-            .Should()
-            .Throw<SettingsException<DummySettings>>()
-            .Where(p => p.ParamName == "settings.SubConfig.Hello" && p.Message.Contains("Dummy") && p.Message.Contains("Hello"));
+        SettingsException<DummySettings> ex = Should.Throw<SettingsException<DummySettings>>(a);
+        ex.ParamName.ShouldBe("settings.SubConfig.Hello");
+        ex.Message.ShouldContain("Dummy");
+        ex.Message.ShouldContain("Hello");
     }
 
     internal class DummySettings : ISettings

--- a/test/Hexalith.UnitTests/Core/Common/Helpers/ExampleTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Helpers/ExampleTest.cs
@@ -7,10 +7,10 @@ namespace Hexalith.UnitTests.Core.Common.Helpers;
 
 using System;
 
-using FluentAssertions;
-
 using Hexalith.Extensions.Common;
 using Hexalith.Extensions.Helpers;
+
+using Shouldly;
 
 /// <summary>
 /// Class ExampleTest.
@@ -23,7 +23,7 @@ public class ExampleTest
     public void BasePropertyWithAttributeShouldHaveValue()
     {
         BasePropertyExample example = ExampleHelper.CreateExample<BasePropertyExample>();
-        _ = example.Value.Should().Be("Hello");
+        example.Value.ShouldBe("Hello");
     }
 
     /// <summary>
@@ -33,8 +33,8 @@ public class ExampleTest
     public void BaseReadOnlyPropertyAndPropertyWithAttributeShouldHaveValue()
     {
         BaseReadOnlyPropertyExample example = ExampleHelper.CreateExample<BaseReadOnlyPropertyExample>();
-        _ = BaseReadOnlyProperty.ReadOnlyValue.Should().Be("Read");
-        _ = example.Value.Should().Be("Hello");
+        BaseReadOnlyProperty.ReadOnlyValue.ShouldBe("Read");
+        example.Value.ShouldBe("Hello");
     }
 
     /// <summary>
@@ -44,9 +44,9 @@ public class ExampleTest
     public void ExampleCreatedIsValid()
     {
         TestExample example = ExampleHelper.CreateExample<TestExample>();
-        _ = example.StringValue.Should().Be("Hello");
-        _ = example.StringDefault.Should().Be("string");
-        _ = example.IntValue.Should().Be(10);
+        example.StringValue.ShouldBe("Hello");
+        example.StringDefault.ShouldBe("string");
+        example.IntValue.ShouldBe(10);
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class ExampleTest
     public void ExampleCreationShouldNotThrowExceptions()
     {
         Action action = () => ExampleHelper.CreateExample<TestExample>();
-        _ = action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class ExampleTest
     public void IntegerWithAttributeShouldHaveValue()
     {
         IntegerExample example = ExampleHelper.CreateExample<IntegerExample>();
-        _ = example.Value.Should().Be(129);
+        example.Value.ShouldBe(129);
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class ExampleTest
     public void IntegerWithNoAttributeShouldHaveValue()
     {
         IntegerDefaultExample example = ExampleHelper.CreateExample<IntegerDefaultExample>();
-        _ = example.Value.Should().Be(101);
+        example.Value.ShouldBe(101);
     }
 
     /// <summary>
@@ -86,7 +86,7 @@ public class ExampleTest
     public void StringWithAttributeShouldHaveValue()
     {
         StringExample example = ExampleHelper.CreateExample<StringExample>();
-        _ = example.Value.Should().Be("Hello");
+        example.Value.ShouldBe("Hello");
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public class ExampleTest
     public void StringWithNoAttributeShouldHaveValue()
     {
         StringDefaultExample example = ExampleHelper.CreateExample<StringDefaultExample>();
-        _ = example.Value.Should().Be("string");
+        example.Value.ShouldBe("string");
     }
 
     /// <summary>

--- a/test/Hexalith.UnitTests/Core/Common/Helpers/ObjectDescriptionHelperTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Helpers/ObjectDescriptionHelperTest.cs
@@ -8,7 +8,7 @@ namespace Hexalith.UnitTests.Core.Common.Helpers;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Extensions.Helpers;
 using Hexalith.Extensions.Reflections;
@@ -25,9 +25,9 @@ public class ObjectDescriptionHelperTest
     public void MappableTypeObjectShouldReturnMapperValue()
     {
         (string type, string name, string description) = ObjectDescriptionHelper.Describe(typeof(MappableTypeTestV2));
-        _ = type.Should().Be("MappableTest");
-        _ = name.Should().Be("Mappable test");
-        _ = description.Should().Be("Mappable test");
+        type.ShouldBe("MappableTest");
+        name.ShouldBe("Mappable test");
+        description.ShouldBe("Mappable test");
     }
 
     /// <summary>
@@ -37,9 +37,9 @@ public class ObjectDescriptionHelperTest
     public void ObjectWithDescriptionAttributeShouldReturnDefinedValue()
     {
         (string type, string name, string description) = ObjectDescriptionHelper.Describe(typeof(DescriptionAttributeTest));
-        _ = type.Should().Be(nameof(DescriptionAttributeTest));
-        _ = name.Should().Be("Description attribute test");
-        _ = description.Should().Be("This class is used to test a class with a description attribute");
+        type.ShouldBe(nameof(DescriptionAttributeTest));
+        name.ShouldBe("Description attribute test");
+        description.ShouldBe("This class is used to test a class with a description attribute");
     }
 
     /// <summary>
@@ -49,9 +49,9 @@ public class ObjectDescriptionHelperTest
     public void ObjectWithDisplayAttributeShouldReturnDefinedValue()
     {
         (string type, string name, string description) = ObjectDescriptionHelper.Describe(typeof(DisplayAttributeTest));
-        _ = type.Should().Be(nameof(DisplayAttributeTest));
-        _ = name.Should().Be("Display attribute example");
-        _ = description.Should().Be("Example of using the display attribute to defined name and description");
+        type.ShouldBe(nameof(DisplayAttributeTest));
+        name.ShouldBe("Display attribute example");
+        description.ShouldBe("Example of using the display attribute to defined name and description");
     }
 
     /// <summary>
@@ -61,9 +61,9 @@ public class ObjectDescriptionHelperTest
     public void ObjectWithDisplayNameAttributeShouldReturnDefinedValue()
     {
         (string type, string name, string description) = ObjectDescriptionHelper.Describe(typeof(DisplayNameAttributeTest));
-        _ = type.Should().Be(nameof(DisplayNameAttributeTest));
-        _ = name.Should().Be("Display name attribute example");
-        _ = description.Should().Be("Display name attribute example");
+        type.ShouldBe(nameof(DisplayNameAttributeTest));
+        name.ShouldBe("Display name attribute example");
+        description.ShouldBe("Display name attribute example");
     }
 
     /// <summary>
@@ -73,9 +73,9 @@ public class ObjectDescriptionHelperTest
     public void ObjectWithNoAttributesShouldReturnTypeName()
     {
         (string type, string name, string description) = ObjectDescriptionHelper.Describe(typeof(NoAttributesTest));
-        _ = type.Should().Be(nameof(NoAttributesTest));
-        _ = name.Should().Be("No attributes test");
-        _ = description.Should().Be("No attributes test");
+        type.ShouldBe(nameof(NoAttributesTest));
+        name.ShouldBe("No attributes test");
+        description.ShouldBe("No attributes test");
     }
 
     /// <summary>

--- a/test/Hexalith.UnitTests/Core/Common/Helpers/ObjectPropertyDescriptionHelperTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Helpers/ObjectPropertyDescriptionHelperTest.cs
@@ -8,7 +8,7 @@ namespace Hexalith.UnitTests.Core.Common.Helpers;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Extensions.Helpers;
 
@@ -22,10 +22,10 @@ public class ObjectPropertyDescriptionHelperTest
     {
         IDictionary<string, (string DisplayName, string Description, object DefaultValue, bool IsRequired)> props = ObjectDescriptionHelper.DescribeProperties(typeof(DefaultValuePropertyAttributeTest));
         (string displayName, string description, object defaultValue, bool isRequired) = props[nameof(DefaultValuePropertyAttributeTest.MyValue)];
-        _ = description.Should().Be("My value");
-        _ = displayName.Should().Be("My value");
-        _ = defaultValue.Should().Be("this value is for me");
-        _ = isRequired.Should().BeFalse();
+        description.ShouldBe("My value");
+        displayName.ShouldBe("My value");
+        defaultValue.ShouldBe("this value is for me");
+        isRequired.ShouldBeFalse();
     }
 
     /// <summary>
@@ -36,10 +36,10 @@ public class ObjectPropertyDescriptionHelperTest
     {
         IDictionary<string, (string DisplayName, string Description, object DefaultValue, bool IsRequired)> props = ObjectDescriptionHelper.DescribeProperties(typeof(DescriptionPropertyAttributeTest));
         (string displayName, string description, object defaultValue, bool isRequired) = props[nameof(DescriptionPropertyAttributeTest.MyValue)];
-        _ = description.Should().Be("This class is used to test a class property with a description attribute");
-        _ = displayName.Should().Be("My value");
-        _ = defaultValue.Should().BeNull();
-        _ = isRequired.Should().BeFalse();
+        description.ShouldBe("This class is used to test a class property with a description attribute");
+        displayName.ShouldBe("My value");
+        defaultValue.ShouldBeNull();
+        isRequired.ShouldBeFalse();
     }
 
     [Fact]
@@ -47,10 +47,10 @@ public class ObjectPropertyDescriptionHelperTest
     {
         IDictionary<string, (string DisplayName, string Description, object DefaultValue, bool IsRequired)> props = ObjectDescriptionHelper.DescribeProperties(typeof(DisplayPropertyAttributeTest));
         (string displayName, string description, object defaultValue, bool isRequired) = props[nameof(DisplayPropertyAttributeTest.MyValue)];
-        _ = description.Should().Be("This class is used to test a class property with a description attribute");
-        _ = displayName.Should().Be("My property value");
-        _ = defaultValue.Should().BeNull();
-        _ = isRequired.Should().BeFalse();
+        description.ShouldBe("This class is used to test a class property with a description attribute");
+        displayName.ShouldBe("My property value");
+        defaultValue.ShouldBeNull();
+        isRequired.ShouldBeFalse();
     }
 
     [Fact]
@@ -58,10 +58,10 @@ public class ObjectPropertyDescriptionHelperTest
     {
         IDictionary<string, (string DisplayName, string Description, object DefaultValue, bool IsRequired)> props = ObjectDescriptionHelper.DescribeProperties(typeof(DisplayNamePropertyAttributeTest));
         (string displayName, string description, object defaultValue, bool isRequired) = props[nameof(DisplayNamePropertyAttributeTest.MyValue)];
-        _ = description.Should().Be("My property value");
-        _ = displayName.Should().Be("My property value");
-        _ = defaultValue.Should().BeNull();
-        _ = isRequired.Should().BeFalse();
+        description.ShouldBe("My property value");
+        displayName.ShouldBe("My property value");
+        defaultValue.ShouldBeNull();
+        isRequired.ShouldBeFalse();
     }
 
     [Fact]
@@ -69,10 +69,10 @@ public class ObjectPropertyDescriptionHelperTest
     {
         IDictionary<string, (string DisplayName, string Description, object DefaultValue, bool IsRequired)> props = ObjectDescriptionHelper.DescribeProperties(typeof(RequiredValuePropertyAttributeTest));
         (string displayName, string description, object defaultValue, bool isRequired) = props[nameof(RequiredValuePropertyAttributeTest.MyValue)];
-        _ = description.Should().Be("My value");
-        _ = displayName.Should().Be("My value");
-        _ = defaultValue.Should().BeNull();
-        _ = isRequired.Should().BeTrue();
+        description.ShouldBe("My value");
+        displayName.ShouldBe("My value");
+        defaultValue.ShouldBeNull();
+        isRequired.ShouldBeTrue();
     }
 
     public class DefaultValuePropertyAttributeTest

--- a/test/Hexalith.UnitTests/Core/Common/Helpers/ObjectToDictionnaryHelper.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Helpers/ObjectToDictionnaryHelper.cs
@@ -7,7 +7,7 @@ namespace Hexalith.UnitTests.Core.Common.Helpers;
 
 using System.Collections.Generic;
 
-using FluentAssertions;
+using Shouldly;
 
 public class ObjectToDictionnaryHelper
 {
@@ -18,12 +18,12 @@ public class ObjectToDictionnaryHelper
         var obj = new { Name = "John", Age = 42 };
         IDictionary<string, object> dico = ToDictionary(obj);
 
-        _ = dico.Should().NotBeNull();
-        _ = dico.Should().HaveCount(2);
-        _ = dico.Should().ContainKey("Name");
-        _ = dico.Should().ContainKey("Age");
-        _ = dico["Name"].Should().Be("John");
-        _ = dico["Age"].Should().Be(42);
+        dico.ShouldNotBeNull();
+        dico.Count.ShouldBe(2);
+        dico.ShouldContainKey("Name");
+        dico.ShouldContainKey("Age");
+        dico["Name"].ShouldBe("John");
+        dico["Age"].ShouldBe(42);
     }
 
     private static IDictionary<string, object> ToDictionary(object obj)

--- a/test/Hexalith.UnitTests/Core/Common/Maths/FibonacciTest.cs
+++ b/test/Hexalith.UnitTests/Core/Common/Maths/FibonacciTest.cs
@@ -5,7 +5,7 @@
 
 namespace Hexalith.UnitTests.Core.Common.Maths;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Extensions.Helpers;
 
@@ -27,6 +27,6 @@ public class FibonacciTest
     public void CheckFirstFibonacciValues(long sequence, long value)
     {
         long result = FibonacciSequence.Number(sequence);
-        _ = result.Should().Be(value);
+        result.ShouldBe(value);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Domain/Events/BaseEventTest.cs
+++ b/test/Hexalith.UnitTests/Core/Domain/Events/BaseEventTest.cs
@@ -7,9 +7,9 @@ namespace Hexalith.UnitTests.Core.Domain.Events;
 
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.PolymorphicSerializations;
+
+using Shouldly;
 
 public class BaseEventTest
 {
@@ -21,9 +21,9 @@ public class BaseEventTest
         DummyEvent1 original = new("IB2343213FR", 655463);
         string json = JsonSerializer.Serialize<Polymorphic>(original, PolymorphicHelper.DefaultJsonSerializerOptions);
         Polymorphic result = JsonSerializer.Deserialize<Polymorphic>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeOfType<DummyEvent1>();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<DummyEvent1>();
+        result.ShouldBeEquivalentTo(original);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class BaseEventTest
         DummyEvent1 original = new("IB2343213FR", 1256);
         string json = JsonSerializer.Serialize(original);
         DummyEvent1 result = JsonSerializer.Deserialize<DummyEvent1>(json);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(original);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Domain/Messages/BaseMessageTest.cs
+++ b/test/Hexalith.UnitTests/Core/Domain/Messages/BaseMessageTest.cs
@@ -7,10 +7,10 @@ namespace Hexalith.UnitTests.Core.Domain.Messages;
 
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.PolymorphicSerializations;
 using Hexalith.UnitTests.Extensions;
+
+using Shouldly;
 
 public class BaseMessageTest
 {
@@ -22,9 +22,9 @@ public class BaseMessageTest
         DummyMessage1 original = new("IB2343213FR", 655463);
         string json = JsonSerializer.Serialize<Polymorphic>(original, PolymorphicHelper.DefaultJsonSerializerOptions);
         object result = JsonSerializer.Deserialize<Polymorphic>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeOfType<DummyMessage1>();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<DummyMessage1>();
+        result.ShouldBeEquivalentTo(original);
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class BaseMessageTest
         DummyMessage1 original = new("IB2343213FR", 1256);
         string json = JsonSerializer.Serialize(original, PolymorphicHelper.DefaultJsonSerializerOptions);
         DummyMessage1 result = JsonSerializer.Deserialize<DummyMessage1>(json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(original);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprHandlers/ActorMessageEnvelopeTest.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprHandlers/ActorMessageEnvelopeTest.cs
@@ -5,13 +5,14 @@
 
 namespace Hexalith.UnitTests.Core.Infrastructure.DaprHandlers;
 
+using System.Runtime.Serialization;
 using System.Text.Json;
-
-using FluentAssertions;
 
 using Hexalith.Infrastructure.DaprRuntime.Actors;
 using Hexalith.PolymorphicSerializations;
 using Hexalith.UnitTests.Core.Application.Commands;
+
+using Shouldly;
 
 /// <summary>
 /// Class ActorMessageEnvelopeTest.
@@ -30,7 +31,7 @@ public class ActorMessageEnvelopeTest
         ActorMessageEnvelope envelope = ActorMessageEnvelope.Create(c1, c1.CreateMetadata());
         string json = JsonSerializer.Serialize(envelope);
         ActorMessageEnvelope result = JsonSerializer.Deserialize<ActorMessageEnvelope>(json);
-        _ = result.Should().BeEquivalentTo(envelope);
+        result.ShouldBeEquivalentTo(envelope);
     }
 
     /// <summary>
@@ -41,7 +42,12 @@ public class ActorMessageEnvelopeTest
     {
         DummyCommand1 c1 = DummyCommand1.Create();
         ActorMessageEnvelope envelope = ActorMessageEnvelope.Create(c1, c1.CreateMetadata());
-        _ = envelope.Should().BeDataContractSerializable();
+        DataContractSerializer serializer = new(typeof(ActorMessageEnvelope));
+        using MemoryStream stream = new();
+        serializer.WriteObject(stream, envelope);
+        stream.Position = 0;
+        ActorMessageEnvelope result = (ActorMessageEnvelope)serializer.ReadObject(stream);
+        result.ShouldBeEquivalentTo(envelope);
     }
 
     /// <summary>
@@ -53,8 +59,8 @@ public class ActorMessageEnvelopeTest
         DummyCommand1 c1 = DummyCommand1.Create();
         ActorMessageEnvelope envelope = ActorMessageEnvelope.Create(c1, c1.CreateMetadata());
         string json = JsonSerializer.Serialize(envelope, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = json.Should().NotBeNullOrWhiteSpace();
-        _ = json.Should().Contain(nameof(envelope.Message));
-        _ = json.Should().Contain(nameof(envelope.Metadata));
+        json.ShouldNotBeNullOrWhiteSpace();
+        json.ShouldContain(nameof(envelope.Message));
+        json.ShouldContain(nameof(envelope.Metadata));
     }
 }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprHandlers/CommandStateTest.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprHandlers/CommandStateTest.cs
@@ -7,11 +7,11 @@ namespace Hexalith.UnitTests.Core.Infrastructure.DaprHandlers;
 
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.Application.States;
 using Hexalith.Applications.States;
 using Hexalith.UnitTests.Core.Application.Commands;
+
+using Shouldly;
 
 public class CommandStateTest
 {
@@ -26,9 +26,12 @@ public class CommandStateTest
             command.CreateMetadata());
         string json = JsonSerializer.Serialize(original);
         MessageState result = JsonSerializer.Deserialize<MessageState>(json);
-        _ = result.Should().NotBeNull();
-        _ = result.Should().BeOfType<MessageState>();
-        _ = result.MessageObject.Should().BeOfType<DummyCommand1>();
-        _ = result.Should().BeEquivalentTo(original);
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<MessageState>();
+        result.MessageObject.ShouldBeOfType<DummyCommand1>();
+
+        // Compare by re-serializing (avoids array/list type mismatch from polymorphic serialization)
+        string resultJson = JsonSerializer.Serialize(result);
+        resultJson.ShouldBe(json);
     }
 }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Process}.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Process}.cs
@@ -8,7 +8,7 @@
 // using Dapr.Actors;
 // using Dapr.Actors.Runtime;
 
-// using FluentAssertions;
+// using Shouldly;
 
 // using Hexalith.Application.Aggregates;
 // using Hexalith.Application.Commands;
@@ -165,12 +165,12 @@
 //            resiliencyPolicyProvider.Object,
 //            actorStateManager.Object);
 //        _ = await actor.ProcessNextCommandAsync();
-//        _ = timerManager.Reminders.Count.Should().Be(1);
-//        _ = timerManager.Reminders.Should().ContainKey(ActorConstants.ProcessReminderName);
+//        timerManager.Reminders.Count.ShouldBe(1);
+//        timerManager.Reminders.ShouldContainKey(ActorConstants.ProcessReminderName);
 
 // // Retry period should be 10 minutes for the first retry plus 3 minutes for the second retry : 13 minutes
 //        _ = timerManager.Reminders[ActorConstants.ProcessReminderName].DueTime.Should().BeCloseTo(TimeSpan.FromMinutes(13), TimeSpan.FromSeconds(5));
-//        _ = timerManager.Timers.Should().HaveCount(1);
+//        timerManager.Timers.Count.ShouldBe(1);
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 
@@ -579,10 +579,10 @@
 //        _ = await actor.ProcessNextCommandAsync();
 //        _ = await actor.ProcessNextCommandAsync();
 //        _ = await actor.ProcessNextCommandAsync();
-//        _ = timerManager.Reminders.Count.Should().Be(1);
-//        _ = timerManager.Timers.Count.Should().Be(2);
-//        _ = timerManager.Reminders[ActorConstants.PublishReminderName].DueTime.Should().Be(TimeSpan.FromMinutes(1));
-//        _ = timerManager.Timers[ActorConstants.PublishTimerName].DueTime.Should().Be(TimeSpan.FromMilliseconds(1));
+//        timerManager.Reminders.Count.ShouldBe(1);
+//        timerManager.Timers.Count.ShouldBe(2);
+//        timerManager.Reminders[ActorConstants.PublishReminderName].DueTime.ShouldBe(TimeSpan.FromMinutes(1));
+//        timerManager.Timers[ActorConstants.PublishTimerName].DueTime.ShouldBe(TimeSpan.FromMilliseconds(1));
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 
@@ -778,9 +778,9 @@
 //            resiliencyPolicyProvider.Object,
 //            actorStateManager.Object);
 //        _ = await actor.ProcessNextCommandAsync();
-//        _ = timerManager.Reminders.Should().HaveCount(1);
-//        _ = timerManager.Reminders.First().Key.Should().Be(ActorConstants.PublishReminderName);
-//        _ = timerManager.Timers.Count.Should().Be(1);
+//        timerManager.Reminders.Count.ShouldBe(1);
+//        timerManager.Reminders.First().Key.ShouldBe(ActorConstants.PublishReminderName);
+//        timerManager.Timers.Count.ShouldBe(1);
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 // }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Publish}.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{Publish}.cs
@@ -8,7 +8,7 @@
 // using Dapr.Actors;
 // using Dapr.Actors.Runtime;
 
-// using FluentAssertions;
+// using Shouldly;
 
 // using Hexalith.Application.Aggregates;
 // using Hexalith.Application.Commands;
@@ -105,9 +105,9 @@
 //            resiliencyPolicyProvider.Object,
 //            actorStateManager.Object);
 //        bool result = await actor.PublishNextMessageAsync();
-//        _ = result.Should().BeFalse();
-//        _ = timerManager.Reminders.Should().BeEmpty();
-//        _ = timerManager.Timers.Should().BeEmpty();
+//        result.ShouldBeFalse();
+//        timerManager.Reminders.ShouldBeEmpty();
+//        timerManager.Timers.ShouldBeEmpty();
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 
@@ -192,11 +192,11 @@
 //            resiliencyPolicyProvider.Object,
 //            actorStateManager.Object);
 //        bool result = await actor.PublishNextMessageAsync();
-//        _ = result.Should().BeTrue();
-//        _ = timerManager.Reminders.Should().HaveCount(1);
-//        _ = timerManager.Reminders[ActorConstants.PublishReminderName].Period.Should().Be(TimeSpan.FromMinutes(1));
-//        _ = timerManager.Timers.Should().HaveCount(1);
-//        _ = timerManager.Timers.First().Key.Should().Be(ActorConstants.PublishTimerName);
+//        result.ShouldBeTrue();
+//        timerManager.Reminders.Count.ShouldBe(1);
+//        timerManager.Reminders[ActorConstants.PublishReminderName].Period.ShouldBe(TimeSpan.FromMinutes(1));
+//        timerManager.Timers.Count.ShouldBe(1);
+//        timerManager.Timers.First().Key.ShouldBe(ActorConstants.PublishTimerName);
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 
@@ -278,11 +278,11 @@
 //            resiliencyPolicyProvider.Object,
 //            actorStateManager.Object);
 //        bool result = await actor.PublishNextMessageAsync();
-//        _ = result.Should().BeTrue();
-//        _ = timerManager.Reminders.Should().HaveCount(1);
-//        _ = timerManager.Reminders[ActorConstants.PublishReminderName].Period.Should().Be(TimeSpan.FromMinutes(1));
-//        _ = timerManager.Timers.Should().HaveCount(1);
-//        _ = timerManager.Timers.First().Key.Should().Be(ActorConstants.PublishTimerName);
+//        result.ShouldBeTrue();
+//        timerManager.Reminders.Count.ShouldBe(1);
+//        timerManager.Reminders[ActorConstants.PublishReminderName].Period.ShouldBe(TimeSpan.FromMinutes(1));
+//        timerManager.Timers.Count.ShouldBe(1);
+//        timerManager.Timers.First().Key.ShouldBe(ActorConstants.PublishTimerName);
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 // }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{submit}.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Actors/AggregateActorTest{submit}.cs
@@ -8,7 +8,7 @@
 // using Dapr.Actors;
 // using Dapr.Actors.Runtime;
 
-// using FluentAssertions;
+// using Shouldly;
 
 // using Hexalith.Application.Aggregates;
 // using Hexalith.Application.Commands;
@@ -127,10 +127,10 @@
 //            resiliencyPolicyProvider.Object,
 //            actorStateManager.Object);
 //        await actor.SubmitCommandAsync(ActorMessageEnvelope.Create(command, metadata));
-//        _ = timerManager.Reminders.Count.Should().Be(1);
-//        _ = timerManager.Timers.Count.Should().Be(1);
-//        _ = timerManager.Reminders[ActorConstants.ProcessReminderName].DueTime.Should().Be(TimeSpan.FromMinutes(1));
-//        _ = timerManager.Timers[ActorConstants.ProcessTimerName].DueTime.Should().Be(TimeSpan.FromMilliseconds(1));
+//        timerManager.Reminders.Count.ShouldBe(1);
+//        timerManager.Timers.Count.ShouldBe(1);
+//        timerManager.Reminders[ActorConstants.ProcessReminderName].DueTime.ShouldBe(TimeSpan.FromMinutes(1));
+//        timerManager.Timers[ActorConstants.ProcessTimerName].DueTime.ShouldBe(TimeSpan.FromMilliseconds(1));
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 
@@ -291,8 +291,8 @@
 //            resiliencyPolicyProvider.Object,
 //            actorStateManager.Object);
 //        await actor.SubmitCommandAsync(ActorMessageEnvelope.Create(command, metadata));
-//        _ = timerManager.Reminders.Count.Should().Be(1);
-//        _ = timerManager.Timers.Count.Should().Be(1);
+//        timerManager.Reminders.Count.ShouldBe(1);
+//        timerManager.Timers.Count.ShouldBe(1);
 //        Mock.VerifyAll(actorStateManager, commandDispatcher, aggregateFactory, eventBus, commandBus, requestBus);
 //    }
 

--- a/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Helpers/DaprActorHelperTest.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/DaprRuntime/Helpers/DaprActorHelperTest.cs
@@ -7,9 +7,9 @@ namespace Hexalith.UnitTests.Core.Infrastructure.DaprRuntime.Helpers;
 
 using Dapr.Actors;
 
-using FluentAssertions;
-
 using Hexalith.Infrastructure.DaprRuntime.Helpers;
+
+using Shouldly;
 
 public class DaprActorHelperTest
 {
@@ -25,8 +25,8 @@ public class DaprActorHelperTest
         ActorId result = id.ToActorId();
 
         // Assert
-        _ = result.Should().NotBeNull();
-        _ = result.ToString().Should().Be(escapedString);
+        result.ShouldNotBeNull();
+        result.ToString().ShouldBe(escapedString);
     }
 
     [Theory]
@@ -41,8 +41,8 @@ public class DaprActorHelperTest
         ActorId result = id.ToActorId();
 
         // Assert
-        _ = result.Should().NotBeNull();
-        _ = result.ToString().Should().Be(escapedString);
+        result.ShouldNotBeNull();
+        result.ToString().ShouldBe(escapedString);
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public class DaprActorHelperTest
         ActorId result = id.ToActorId();
 
         // Assert
-        _ = result.Should().NotBeNull();
-        _ = result.ToString().Should().Be(id);
+        result.ShouldNotBeNull();
+        result.ToString().ShouldBe(id);
     }
 
     [Fact]
@@ -69,8 +69,8 @@ public class DaprActorHelperTest
         Dapr.Actors.ActorId result = actorIdString.ToActorId();
 
         // Assert
-        _ = result.Should().NotBeNull();
-        _ = result.ToString().Should().Be(actorIdString);
+        result.ShouldNotBeNull();
+        result.ToString().ShouldBe(actorIdString);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class DaprActorHelperTest
         Action act = () => actorIdString.ToActorId();
 
         // Assert
-        _ = act.Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(act);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class DaprActorHelperTest
         Action act = () => actorIdString.ToActorId();
 
         // Assert
-        _ = act.Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(act);
     }
 
     [Theory]
@@ -109,7 +109,7 @@ public class DaprActorHelperTest
         string result = aggregateName.ToAggregateActorName();
 
         // Assert
-        _ = result.Should().Be(expected);
+        result.ShouldBe(expected);
     }
 
     [Theory]
@@ -125,7 +125,7 @@ public class DaprActorHelperTest
         string result = aggregateName.ToAggregateActorName();
 
         // Assert
-        _ = result.Should().Be(actorName);
+        result.ShouldBe(actorName);
     }
 
     [Theory]
@@ -138,7 +138,7 @@ public class DaprActorHelperTest
         Action act = () => aggregateName.ToAggregateActorName();
 
         // Assert
-        _ = act.Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(act);
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class DaprActorHelperTest
         Action act = () => aggregateName.ToAggregateActorName();
 
         // Assert
-        _ = act.Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(act);
     }
 
     [Theory]
@@ -167,7 +167,7 @@ public class DaprActorHelperTest
         string result = DaprActorHelper.ToAggregateName(actorName);
 
         // Assert
-        _ = result.Should().Be(aggregateName);
+        result.ShouldBe(aggregateName);
     }
 
     [Theory]
@@ -182,8 +182,8 @@ public class DaprActorHelperTest
         string result = new ActorId(escapedString).ToUnescapeString();
 
         // Assert
-        _ = result.Should().NotBeNull();
-        _ = result.Should().Be(id);
+        result.ShouldNotBeNull();
+        result.ShouldBe(id);
     }
 
     [Fact]
@@ -196,7 +196,7 @@ public class DaprActorHelperTest
         Action act = () => new ActorId(escapedString).ToUnescapeString();
 
         // Assert
-        _ = act.Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(act);
     }
 
     [Fact]
@@ -209,7 +209,7 @@ public class DaprActorHelperTest
         string result = new ActorId(escapedString).ToUnescapeString();
 
         // Assert
-        _ = result.Should().NotBeNull();
-        _ = result.Should().Be("123/4");
+        result.ShouldNotBeNull();
+        result.ShouldBe("123/4");
     }
 }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/Prompts/CommandPromptGenerationTest.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/Prompts/CommandPromptGenerationTest.cs
@@ -5,10 +5,10 @@
 
 namespace Hexalith.UnitTests.Core.Infrastructure.Prompts;
 
-using FluentAssertions;
-
 using Hexalith.Commons.UniqueIds;
 using Hexalith.Extensions.Helpers;
+
+using Shouldly;
 
 public class CommandPromptGenerationTest
 {
@@ -28,23 +28,22 @@ public class CommandPromptGenerationTest
             userEmail,
             userName,
             "en-US",
-            correlationId)
-;
+            correlationId);
 
         // Assert
-        _ = prompt.Should().NotBeNullOrEmpty();
-        _ = prompt.Should().Contain(correlationId);
-        _ = prompt.Should().Contain(assistantEmail);
-        _ = prompt.Should().Contain(assistantName);
-        _ = prompt.Should().Contain(userEmail);
-        _ = prompt.Should().Contain(userName);
-        _ = prompt.Should().Contain(command.DomainName);
-        _ = prompt.Should().Contain(nameof(AddCountryCommand.Name));
-        _ = prompt.Should().Contain(nameof(AddCountryCommand.IsoNumber));
-        _ = prompt.Should().Contain(nameof(AddCountryCommand.CurrencyName));
-        _ = prompt.Should().Contain(nameof(AddCountryCommand.CurrencySymbol));
-        _ = prompt.Should().Contain(nameof(AddCountryCommand.Iso2));
-        _ = prompt.Should().Contain(nameof(AddCountryCommand.Iso3));
-        _ = prompt.Should().Contain(nameof(AddCountryCommand.IsoNumber));
+        prompt.ShouldNotBeNullOrEmpty();
+        prompt.ShouldContain(correlationId);
+        prompt.ShouldContain(assistantEmail);
+        prompt.ShouldContain(assistantName);
+        prompt.ShouldContain(userEmail);
+        prompt.ShouldContain(userName);
+        prompt.ShouldContain(command.DomainName);
+        prompt.ShouldContain(nameof(AddCountryCommand.Name));
+        prompt.ShouldContain(nameof(AddCountryCommand.IsoNumber));
+        prompt.ShouldContain(nameof(AddCountryCommand.CurrencyName));
+        prompt.ShouldContain(nameof(AddCountryCommand.CurrencySymbol));
+        prompt.ShouldContain(nameof(AddCountryCommand.Iso2));
+        prompt.ShouldContain(nameof(AddCountryCommand.Iso3));
+        prompt.ShouldContain(nameof(AddCountryCommand.IsoNumber));
     }
 }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/Serialization/IsoUtcDateTimeOffsetConverterTest.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/Serialization/IsoUtcDateTimeOffsetConverterTest.cs
@@ -8,7 +8,7 @@ namespace Hexalith.UnitTests.Core.Infrastructure.Serialization;
 using System;
 using System.Text.Json;
 
-using FluentAssertions;
+using Shouldly;
 
 using Hexalith.Infrastructure.Serialization.Serialization;
 
@@ -24,7 +24,7 @@ public class IsoUtcDateTimeOffsetConverterTest
         DateTimeOffset date = JsonSerializer.Deserialize<DateTimeOffset>(
             json,
             options);
-        _ = date.Should().Be(new DateTimeOffset(
+        date.ShouldBe(new DateTimeOffset(
             2022,
             5,
             6,
@@ -45,6 +45,6 @@ public class IsoUtcDateTimeOffsetConverterTest
             date,
             options);
         DateTimeOffset d = date.ToUniversalTime();
-        _ = json.Should().Be($"\"{d.Year:D4}-{d.Month:D2}-{d.Day:D2}T{d.Hour:D2}:{d.Minute:D2}:{d.Second:D2}Z\"");
+        json.ShouldBe($"\"{d.Year:D4}-{d.Month:D2}-{d.Day:D2}T{d.Hour:D2}:{d.Minute:D2}:{d.Second:D2}Z\"");
     }
 }

--- a/test/Hexalith.UnitTests/Core/Infrastructure/States/MessageStateTest.cs
+++ b/test/Hexalith.UnitTests/Core/Infrastructure/States/MessageStateTest.cs
@@ -8,13 +8,13 @@ namespace Hexalith.UnitTests.Core.Infrastructure.States;
 using System;
 using System.Text.Json;
 
-using FluentAssertions;
-
 using Hexalith.Applications.States;
 using Hexalith.Commons.Metadatas;
 using Hexalith.Commons.Strings;
 using Hexalith.PolymorphicSerializations;
 using Hexalith.UnitTests.Core.Application.Commands;
+
+using Shouldly;
 
 public class MessageStateTest
 {
@@ -52,20 +52,21 @@ public class MessageStateTest
     public void DeserializeShouldSucceed()
     {
         MessageState state = JsonSerializer.Deserialize<MessageState>(_json, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = state.Should().NotBeNull();
-        _ = state.Message.Should().NotBeNull();
-        _ = state.MessageObject.Should().NotBeNull();
-        _ = state.MessageObject.Should().BeOfType<DummyCommand1>();
-        _ = state.MessageObject.As<DummyCommand1>().Value1.Should().Be(123456);
-        _ = state.MessageObject.As<DummyCommand1>().BaseValue.Should().Be("Test");
-        _ = state.Metadata.Should().NotBeNull();
-        _ = state.Metadata!.Context.Should().NotBeNull();
-        _ = state.Metadata.Context!.CorrelationId.Should().Be("COR1234566");
-        _ = state.Metadata.Context.UserId.Should().Be("TestUser");
-        _ = state.Metadata.Message.Should().NotBeNull();
-        _ = state.Metadata.Message.Id.Should().Be("23rZSlC-ukyRtjuSQfI6BQ");
-        _ = state.Metadata.Message.Name.Should().Be("DummyCommand1");
-        _ = state.Metadata.Message.Version.Should().Be(1);
+        state.ShouldNotBeNull();
+        state.Message.ShouldNotBeNull();
+        state.MessageObject.ShouldNotBeNull();
+        state.MessageObject.ShouldBeOfType<DummyCommand1>();
+        DummyCommand1 cmd = (DummyCommand1)state.MessageObject;
+        cmd.Value1.ShouldBe(123456);
+        cmd.BaseValue.ShouldBe("Test");
+        state.Metadata.ShouldNotBeNull();
+        state.Metadata!.Context.ShouldNotBeNull();
+        state.Metadata.Context!.CorrelationId.ShouldBe("COR1234566");
+        state.Metadata.Context.UserId.ShouldBe("TestUser");
+        state.Metadata.Message.ShouldNotBeNull();
+        state.Metadata.Message.Id.ShouldBe("23rZSlC-ukyRtjuSQfI6BQ");
+        state.Metadata.Message.Name.ShouldBe("DummyCommand1");
+        state.Metadata.Message.Version.ShouldBe(1);
     }
 
     [Fact]
@@ -87,14 +88,14 @@ public class MessageStateTest
                         "session-56",
                         [])));
         string json = JsonSerializer.Serialize(messageState, PolymorphicHelper.DefaultJsonSerializerOptions);
-        _ = json.Should().NotBeEmpty();
-        _ = json.Should().Contain(PolymorphicHelper.Discriminator);
-        _ = json.Should().Contain(nameof(DummyCommand1));
-        _ = json.Should().Contain(messageState.Metadata.Context.CorrelationId);
-        _ = json.Should().Contain(nameof(DummyCommand1.Value1));
-        _ = json.Should().Contain(command.Value1.ToInvariantString());
-        _ = json.Should().Contain(nameof(DummyCommand1.BaseValue));
-        _ = json.Should().Contain(command.BaseValue);
-        _ = json.Should().Contain(messageState.Metadata.Message.Id);
+        json.ShouldNotBeEmpty();
+        json.ShouldContain(PolymorphicHelper.Discriminator);
+        json.ShouldContain(nameof(DummyCommand1));
+        json.ShouldContain(messageState.Metadata.Context.CorrelationId);
+        json.ShouldContain(nameof(DummyCommand1.Value1));
+        json.ShouldContain(command.Value1.ToInvariantString());
+        json.ShouldContain(nameof(DummyCommand1.BaseValue));
+        json.ShouldContain(command.BaseValue);
+        json.ShouldContain(messageState.Metadata.Message.Id);
     }
 }

--- a/test/Hexalith.UnitTests/Core/UI/Components/MenuItemInformationTest.cs
+++ b/test/Hexalith.UnitTests/Core/UI/Components/MenuItemInformationTest.cs
@@ -5,9 +5,9 @@
 
 namespace Hexalith.UnitTests.Core.UI.Components;
 
-using FluentAssertions;
-
 using Hexalith.UI.Components;
+
+using Shouldly;
 
 public class MenuItemInformationTest
 {
@@ -29,8 +29,8 @@ public class MenuItemInformationTest
         (bool found, int last) = menuItem.GetMenuItemIndex(0, new MenuItemInformation("Not Found", "/not-found", null, false, 0, null, []));
 
         // Assert
-        _ = found.Should().BeFalse();
-        _ = last.Should().Be(2);
+        found.ShouldBeFalse();
+        last.ShouldBe(2);
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class MenuItemInformationTest
         (bool found, int last) = menuItem.GetMenuItemIndex(0, foundItem);
 
         // Assert
-        _ = found.Should().BeTrue();
-        _ = last.Should().Be(10);
+        found.ShouldBeTrue();
+        last.ShouldBe(10);
     }
 }


### PR DESCRIPTION
## Summary

- Convert all remaining 37 test files from FluentAssertions to Shouldly
- Update assertion syntax throughout the test suite
- Replace FluentAssertions-specific features with Shouldly equivalents
- Fix serialization round-trip tests to avoid type mismatch issues

## Changes

### Assertion Library Migration
All test files now use Shouldly exclusively. Key conversions include:
- `x.Should().Be(y)` → `x.ShouldBe(y)`
- `x.Should().NotBeNull()` → `x.ShouldNotBeNull()`
- `x.Should().Throw<T>()` → `Should.Throw<T>(x)`
- `x.Should().BeCloseTo(y, tolerance)` → Manual time difference checks
- `x.Should().BeApproximately(y, delta)` → `Math.Abs(x - y).ShouldBeLessThan(delta)`
- `x.Should().BeDataContractSerializable()` → Manual DataContractSerializer tests

### Serialization Test Fixes
Tests comparing serialized/deserialized objects now compare JSON strings instead of using `ShouldBeEquivalentTo`. This avoids failures caused by System.Text.Json polymorphic deserialization converting `string[]` to `List<string>`.

## Test plan

- [x] All 290 unit tests pass
- [x] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)